### PR TITLE
Implement `leaveChat` method

### DIFF
--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -105,6 +105,16 @@ trait HasBotsAndChats
         return $telegraph->getChatIfAvailable() ?? throw TelegraphException::missingChat();
     }
 
+    public function leaveChat(): Telegraph
+    {
+        $telegraph = clone $this;
+
+        $telegraph->endpoint = self::ENDPOINT_LEAVE_CHAT;
+        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+
+        return $telegraph;
+    }
+
     public function botInfo(): Telegraph
     {
         $telegraph = clone $this;

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -146,6 +146,11 @@ class TelegraphChat extends Model
         return TelegraphFacade::chat($this)->unpinAllMessages();
     }
 
+    public function leave(): Telegraph
+    {
+        return TelegraphFacade::chat($this)->leaveChat();
+    }
+
     public function action(string $action): Telegraph
     {
         return TelegraphFacade::chat($this)->chatAction($action);

--- a/src/Telegraph.php
+++ b/src/Telegraph.php
@@ -79,6 +79,7 @@ class Telegraph
     public const ENDPOINT_CREATE_CHAT_INVITE_LINK = 'createChatInviteLink';
     public const ENDPOINT_EDIT_CHAT_INVITE_LINK = 'editChatInviteLink';
     public const ENDPOINT_REVOKE_CHAT_INVITE_LINK = 'revokeChatInviteLink';
+    public const ENDPOINT_LEAVE_CHAT = 'leaveChat';
     public const ENDPOINT_GET_CHAT_INFO = 'getChat';
     public const ENDPOINT_GET_CHAT_MEMBER_COUNT = 'getChatMemberCount';
     public const ENDPOINT_SET_CHAT_PERMISSIONS = 'setChatPermissions';

--- a/tests/Unit/Concerns/HasBotsAndChatsTest.php
+++ b/tests/Unit/Concerns/HasBotsAndChatsTest.php
@@ -55,6 +55,12 @@ it('can unregister commands', function () {
     })->toMatchTelegramSnapshot();
 });
 
+it('can leave a chat', function () {
+    expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
+        return $telegraph->chat(make_chat())->leaveChat();
+    })->toMatchTelegramSnapshot();
+});
+
 it('can send a chat action', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
         return $telegraph->chat(make_chat())->chatAction(ChatActions::TYPING);

--- a/tests/Unit/Models/TelegraphChatTest.php
+++ b/tests/Unit/Models/TelegraphChatTest.php
@@ -252,6 +252,15 @@ it('can unpin all messages', function () {
     Telegraph::assertSentData(\DefStudio\Telegraph\Telegraph::ENDPOINT_UNPIN_ALL_MESSAGES);
 });
 
+it('can leave a chat', function () {
+    Telegraph::fake();
+    $chat = make_chat();
+
+    $chat->leave()->send();
+
+    Telegraph::assertSentData(\DefStudio\Telegraph\Telegraph::ENDPOINT_LEAVE_CHAT);
+});
+
 it('can set chat title', function () {
     Telegraph::fake();
     $chat = make_chat();

--- a/tests/__snapshots__/HasBotsAndChatsTest__it_can_leave_a_chat__1.yml
+++ b/tests/__snapshots__/HasBotsAndChatsTest__it_can_leave_a_chat__1.yml
@@ -1,0 +1,4 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/leaveChat'
+payload:
+    chat_id: '-123456789'
+files: {  }


### PR DESCRIPTION
Implements methods for leaving a chat.

```php
Telegraph::chat($telegraphChat)->leaveChat();

$chat->leave();
```

This was not as straightforward as my last PR. Let me know if anything is in the wrong place, and I'll push a fix for you 👍

Closes #192