### PR TITLE
[feat] forwardMessage method #184

### DIFF
--- a/docs/content/en/features/telegram-api-calls.md
+++ b/docs/content/en/features/telegram-api-calls.md
@@ -74,6 +74,14 @@ deletes a message
 Telegraph::deleteMessage($messageId)->send();
 ```
 
+## forwardMessage
+
+forwards a message from another chat
+
+```php
+Telegraph::forwardMessage($fromChat, $messageId)->send();
+```
+
 ## pinMessage
 
 pins a message

--- a/docs/content/en/models/telegraph-chat.md
+++ b/docs/content/en/models/telegraph-chat.md
@@ -149,6 +149,16 @@ Starts a `Telegraph` call to delete a message
 $telegraphChat->deleteMessage($messageId)->send();
 ```
 
+### `forwardMessage()`
+
+forwards a message from another chat
+
+```php
+/** @var \DefStudio\Telegraph\Models\TelegraphChat $telegraphChat */
+
+$telegraphChat->forwardMessage($fromChat, $messageId)->send();
+```
+
 ### `pinMessage()`
 
 Starts a `Telegraph` call to pin a message

--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -150,9 +150,9 @@ trait ComposesMessages
         return $telegraph;
     }
 
-    public function forwardMessage(TelegraphChat|int $from_chat_id, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $fromChatId, int $messageId): Telegraph
     {
-        $from_chat_id = is_int($from_chat_id) ? $from_chat_id : $from_chat_id->chat_id;
+        $fromChatId = is_int($fromChatId) ? $fromChatId : $fromChatId->chat_id;
 
         $telegraph = clone $this;
 
@@ -160,7 +160,7 @@ trait ComposesMessages
         $telegraph->data = [
             'chat_id' => $telegraph->getChat()->chat_id,
             'message_id' => $messageId,
-            'from_chat_id' => $from_chat_id,
+            'from_chat_id' => $fromChatId,
         ];
 
         return $telegraph;

--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -148,4 +148,18 @@ trait ComposesMessages
 
         return $telegraph;
     }
+
+    public function forwardMessage(int $originalChatId, int $messageId): Telegraph
+    {
+        $telegraph = clone $this;
+
+        $telegraph->endpoint = self::ENDPOINT_FORWARD_MESSAGE;
+        $telegraph->data = [
+            'chat_id' => $telegraph->getChat()->chat_id,
+            'message_id' => $messageId,
+            'from_chat_id' => $originalChatId,
+        ];
+
+        return $telegraph;
+    }
 }

--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -4,6 +4,7 @@
 
 namespace DefStudio\Telegraph\Concerns;
 
+use DefStudio\Telegraph\Models\TelegraphChat;
 use DefStudio\Telegraph\Telegraph;
 
 trait ComposesMessages
@@ -149,15 +150,17 @@ trait ComposesMessages
         return $telegraph;
     }
 
-    public function forwardMessage(int $originalChatId, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $from_chat_id, int $messageId): Telegraph
     {
+        $from_chat_id = is_int($from_chat_id) ? $from_chat_id : $from_chat_id->chat_id;
+
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_FORWARD_MESSAGE;
         $telegraph->data = [
             'chat_id' => $telegraph->getChat()->chat_id,
             'message_id' => $messageId,
-            'from_chat_id' => $originalChatId,
+            'from_chat_id' => $from_chat_id,
         ];
 
         return $telegraph;

--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -150,9 +150,9 @@ trait ComposesMessages
         return $telegraph;
     }
 
-    public function forwardMessage(TelegraphChat|int $fromChatId, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $fromChat, int $messageId): Telegraph
     {
-        $fromChatId = is_int($fromChatId) ? $fromChatId : $fromChatId->chat_id;
+        $fromChatId = is_int($fromChat) ? $fromChat : $fromChat->chat_id;
 
         $telegraph = clone $this;
 

--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \DefStudio\Telegraph\Telegraph  replaceKeyboard(string $messageId, Keyboard|callable $newKeyboard)
  * @method static \DefStudio\Telegraph\Telegraph  deleteKeyboard(string $messageId)
  * @method static \DefStudio\Telegraph\Telegraph  deleteMessage(string $messageId)
+ * @method static \DefStudio\Telegraph\Telegraph  forwardMessage($fromChat, $messageId)
  * @method static \DefStudio\Telegraph\Telegraph  pinMessage(string $messageId)
  * @method static \DefStudio\Telegraph\Telegraph  unpinMessage(string $messageId)
  * @method static \DefStudio\Telegraph\Telegraph  unpinAllMessages()

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -272,8 +272,8 @@ class TelegraphChat extends Model
         return TelegraphFacade::chat($this)->quiz($question);
     }
 
-    public function forwardMessage(TelegraphChat|int $from_chat_id, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $fromChatId, int $messageId): Telegraph
     {
-        return TelegraphFacade::chat($this)->forwardMessage($from_chat_id, $messageId);
+        return TelegraphFacade::chat($this)->forwardMessage($fromChatId, $messageId);
     }
 }

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -272,8 +272,8 @@ class TelegraphChat extends Model
         return TelegraphFacade::chat($this)->quiz($question);
     }
 
-    public function forwardMessage(TelegraphChat|int $fromChatId, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $fromChat, int $messageId): Telegraph
     {
-        return TelegraphFacade::chat($this)->forwardMessage($fromChatId, $messageId);
+        return TelegraphFacade::chat($this)->forwardMessage($fromChat, $messageId);
     }
 }

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -272,8 +272,8 @@ class TelegraphChat extends Model
         return TelegraphFacade::chat($this)->quiz($question);
     }
 
-    public function forwardMessage(int $originalChatId, int $messageId): Telegraph
+    public function forwardMessage(TelegraphChat|int $from_chat_id, int $messageId): Telegraph
     {
-        return TelegraphFacade::chat($this)->forwardMessage($originalChatId, $messageId);
+        return TelegraphFacade::chat($this)->forwardMessage($from_chat_id, $messageId);
     }
 }

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -271,4 +271,9 @@ class TelegraphChat extends Model
     {
         return TelegraphFacade::chat($this)->quiz($question);
     }
+
+    public function forwardMessage(int $originalChatId, int $messageId): Telegraph
+    {
+        return TelegraphFacade::chat($this)->forwardMessage($originalChatId, $messageId);
+    }
 }

--- a/src/Telegraph.php
+++ b/src/Telegraph.php
@@ -91,6 +91,7 @@ class Telegraph
     public const ENDPOINT_RESTRICT_CHAT_MEMBER = 'restrictChatMember';
     public const ENDPOINT_PROMOTE_CHAT_MEMBER = 'promoteChatMember';
     public const ENDPOINT_SEND_POLL = 'sendPoll';
+    public const ENDPOINT_FORWARD_MESSAGE = 'forwardMessage';
 
 
     /** @var array<string, mixed> */

--- a/tests/Unit/Concerns/ComposesMessagesTest.php
+++ b/tests/Unit/Concerns/ComposesMessagesTest.php
@@ -58,3 +58,8 @@ it('can edit a message', function (callable $setupClosure) {
     'edit before text' => fn () => fn (Telegraph $telegraph) => $telegraph->edit(123456)->markdown('new text'),
     'edit after text' => fn () => fn (Telegraph $telegraph) => $telegraph->markdown('new text')->edit(123456),
 ]);
+
+it('can forward a message', function () {
+    expect(fn (Telegraph $telegraph) => $telegraph->forwardMessage(123456789, 123456))
+        ->toMatchTelegramSnapshot();
+});

--- a/tests/Unit/Concerns/ComposesMessagesTest.php
+++ b/tests/Unit/Concerns/ComposesMessagesTest.php
@@ -60,6 +60,8 @@ it('can edit a message', function (callable $setupClosure) {
 ]);
 
 it('can forward a message', function () {
-    expect(fn (Telegraph $telegraph) => $telegraph->forwardMessage(123456789, 123456))
+    $chat = make_chat();
+
+    expect(fn (Telegraph $telegraph) => $telegraph->forwardMessage($chat, 123456))
         ->toMatchTelegramSnapshot();
 });

--- a/tests/Unit/Models/TelegraphChatTest.php
+++ b/tests/Unit/Models/TelegraphChatTest.php
@@ -470,3 +470,15 @@ it('can create a quiz', function () {
 
     TelegraphQuizFake::assertSentQuiz('foo?', ['bar!', 'baz!'], 1);
 });
+
+it('can forward a message', function () {
+    Telegraph::fake();
+    $chat = make_chat();
+
+    $chat->forwardMessage(123456789, 123)->send();
+
+    Telegraph::assertSentData(\DefStudio\Telegraph\Telegraph::ENDPOINT_FORWARD_MESSAGE, [
+        'from_chat_id' => 123456789,
+        'message_id' => 123,
+    ]);
+});

--- a/tests/Unit/Models/TelegraphChatTest.php
+++ b/tests/Unit/Models/TelegraphChatTest.php
@@ -475,10 +475,10 @@ it('can forward a message', function () {
     Telegraph::fake();
     $chat = make_chat();
 
-    $chat->forwardMessage(123456789, 123)->send();
+    $chat->forwardMessage($chat, 123)->send();
 
     Telegraph::assertSentData(\DefStudio\Telegraph\Telegraph::ENDPOINT_FORWARD_MESSAGE, [
-        'from_chat_id' => 123456789,
+        'from_chat_id' => $chat->chat_id,
         'message_id' => 123,
     ]);
 });

--- a/tests/__snapshots__/ComposesMessagesTest__it_can_forward_a_message__1.yml
+++ b/tests/__snapshots__/ComposesMessagesTest__it_can_forward_a_message__1.yml
@@ -2,5 +2,5 @@ url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/forwardMe
 payload:
     chat_id: '-123456789'
     message_id: 123456
-    from_chat_id: 123456789
+    from_chat_id: '-123456789'
 files: {  }

--- a/tests/__snapshots__/ComposesMessagesTest__it_can_forward_a_message__1.yml
+++ b/tests/__snapshots__/ComposesMessagesTest__it_can_forward_a_message__1.yml
@@ -1,0 +1,6 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/forwardMessage'
+payload:
+    chat_id: '-123456789'
+    message_id: 123456
+    from_chat_id: 123456789
+files: {  }


### PR DESCRIPTION
Implements methods for forward a message.

`Telegraph::forwardMessage($fromChatId, $messageId)->send();`

Closes #184