### PR TITLE
docs: Fix typo in messages section

### DIFF
--- a/docs/content/en/features/messages.md
+++ b/docs/content/en/features/messages.md
@@ -17,7 +17,7 @@ $chat = TelegraphChat::find(44);
 // this will use the default parsing method set in config/telegraph.php
 $chat->message('hello')->send();
 
-$chat->html("<b>hello<b>\n\nI'm a bot!")->send();
+$chat->html("<b>hello</b>\n\nI'm a bot!")->send();
 
 $chat->markdown('*hello*')->send();
 ```


### PR DESCRIPTION
Html messages only works with valid html