### PR TITLE
Add long pulling support for getUpdates() method

### DIFF
--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -124,7 +124,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function botUpdates(?int $offset, int $timeout = 0): Telegraph
+    public function botUpdates(?int $offset = null, int $timeout = 0): Telegraph
     {
         $telegraph = clone $this;
 

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -124,11 +124,17 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function botUpdates(): Telegraph
+    public function botUpdates(?int $offset, int $timeout = 0): Telegraph
     {
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_BOT_UPDATES;
+
+        if ($offset) {
+            $telegraph->data['offset'] = $offset;
+        }
+
+        $telegraph->data['timeout'] = $timeout;
 
         return $telegraph;
     }

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -40,6 +40,10 @@ trait InteractsWithTelegram
             $request
         );
 
+        if (array_key_exists('timeout', $this->data) && $this->data['timeout'] > 0) {
+            $request->timeout($this->data['timeout']);
+        }
+
         return $request->post($this->getApiUrl(), $this->prepareData($asMultipart));
     }
 

--- a/src/Models/TelegraphBot.php
+++ b/src/Models/TelegraphBot.php
@@ -160,9 +160,9 @@ class TelegraphBot extends Model
     /**
      * @return \Illuminate\Support\Collection<int, TelegramUpdate>
      */
-    public function updates(): \Illuminate\Support\Collection
+    public function updates(?int $offset, int $timeout = 0): \Illuminate\Support\Collection
     {
-        $reply = TelegraphFacade::bot($this)->botUpdates()->send();
+        $reply = TelegraphFacade::bot($this)->botUpdates($offset, $timeout)->send();
 
         if ($reply->telegraphError()) {
             if (!$reply->successful()) {

--- a/src/Models/TelegraphBot.php
+++ b/src/Models/TelegraphBot.php
@@ -160,7 +160,7 @@ class TelegraphBot extends Model
     /**
      * @return \Illuminate\Support\Collection<int, TelegramUpdate>
      */
-    public function updates(?int $offset, int $timeout = 0): \Illuminate\Support\Collection
+    public function updates(?int $offset = null, int $timeout = 0): \Illuminate\Support\Collection
     {
         $reply = TelegraphFacade::bot($this)->botUpdates($offset, $timeout)->send();
 


### PR DESCRIPTION
It is very handy sometimes to use long pooling instead of webhook. 
Telegram documentation states that it is ok to use getUpdates() method.

This PR adds two parameters to updates() method: offset and timeout, so one can use them to implement long pooling.

This PR does not introduce any BC. 