### PR TITLE
[feat] custom webhook domain

### DIFF
--- a/config/telegraph.php
+++ b/config/telegraph.php
@@ -24,6 +24,14 @@ return [
     'webhook_handler' => DefStudio\Telegraph\Handlers\EmptyWebhookHandler::class,
 
     /*
+     * Sets a custom domain when registering a webhook. This will allow a loca telegram bot api server
+     * to reach the webhook. Disabled by default
+     *
+     * For reference, see https://core.telegram.org/bots/api#using-a-local-bot-api-server
+     */
+    // 'custom_webhook_domain' => 'http://my.custom.domain';
+
+    /*
      * If enabled, Telegraph dumps received
      * webhook messages to logs
      */

--- a/docs/content/en/installation.md
+++ b/docs/content/en/installation.md
@@ -54,6 +54,14 @@ return [
      * For reference, see https://defstudio.github.io/telegraph/webhooks/overview
      */
     'webhook_handler' => EmptyWebhookHandler::class,
+    
+    /*
+     * Sets a custom domain when registering a webhook. This will allow a loca telegram bot api server
+     * to reach the webhook. Disabled by default
+     *
+     * For reference, see https://core.telegram.org/bots/api#using-a-local-bot-api-server
+     */
+    // 'custom_webhook_domain' => 'http://my.custom.domain';
 
     /*
      * If enabled, Telegraph dumps received

--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -12,19 +12,30 @@ use DefStudio\Telegraph\Telegraph;
  */
 trait InteractsWithWebhooks
 {
+    private function getWebhookUrl(): string
+    {
+        $customWebhookUrl = config('custom_webhook_domain');
+
+        if ($customWebhookUrl === null) {
+            $url = route('telegraph.webhook', $this->getBot());
+
+            if (!str_starts_with($url, 'https://')) {
+                throw TelegramWebhookException::invalidScheme();
+            }
+
+            return $url;
+        }
+
+        return $customWebhookUrl . route('telegraph.webhook', $this->getBot(), false);
+    }
+
     public function registerWebhook(): Telegraph
     {
         $telegraph = clone $this;
 
-        $url = route('telegraph.webhook', $telegraph->getBot());
-
-        if (!str_starts_with($url, 'https://')) {
-            throw TelegramWebhookException::invalidScheme();
-        }
-
         $telegraph->endpoint = self::ENDPOINT_SET_WEBHOOK;
         $telegraph->data = [
-            'url' => $url,
+            'url' => $this->getWebhookUrl(),
         ];
 
         return $telegraph;

--- a/tests/Unit/Concerns/InteractsWithWebhooksTest.php
+++ b/tests/Unit/Concerns/InteractsWithWebhooksTest.php
@@ -11,6 +11,15 @@ it('can register a webhook', function () {
         ->toMatchTelegramSnapshot();
 });
 
+it('can register a webhook with a custom domain', function () {
+    withfakeUrl();
+
+    config()->set('custom_webhook_domain', 'http://foo.bar.baz');
+
+    expect(fn (Telegraph $telegraph) => $telegraph->bot(make_bot())->registerWebhook())
+        ->toMatchTelegramSnapshot();
+});
+
 it('requires an https url to register a webhook', function () {
     \DefStudio\Telegraph\Facades\Telegraph::bot(make_bot())->registerWebhook();
 })->throws(TelegramWebhookException::class, 'You application must have a secure (https) url in order to accept webhook calls');

--- a/tests/__snapshots__/InteractsWithWebhooksTest__it_can_register_a_webhook_with_a_custom_domain__1.yml
+++ b/tests/__snapshots__/InteractsWithWebhooksTest__it_can_register_a_webhook_with_a_custom_domain__1.yml
@@ -1,0 +1,4 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/setWebhook'
+payload:
+    url: 'http://foo.bar.baz/telegraph/3f3814e1-5836-3d77-904e-60f64b15df36/webhook'
+files: {  }


### PR DESCRIPTION
Adds a new `custom_webhook_domain` configuration key to force a different domain when registering a webhook

fix #254 