### PR TITLE
[feat] model storage

### DIFF
--- a/docs/content/en/storage/entities_storage.md
+++ b/docs/content/en/storage/entities_storage.md
@@ -7,9 +7,22 @@ fullscreen: false
 position: 70
 ---
 
-**Telegraph** offers a quick, multi driver, data storage solution to save and retrieve information about Bots, Chats and Users. A fine grained configuration is available in the `storage` section of Telegraph [configuration file](installation#configuration) 
+**Telegraph** offers a quick, multi driver, data storage solution to save and retrieve information about Bots, Chats and Users. A fine grained configuration is available in the `storage` section of Telegraph [configuration file](installation#configuration)
 
-## Overview
+## Storages Available
+
+Telegraph implements, by default, contextual storage for Bots, Chats and User DTOs. Additionally a storage can be added to every class, it is only needed to implement the `\DefStudio\Telegraph\Contracts\Storable` contract and use the `\DefStudio\Telegraph\Concerns\HasStorage` trait:
+
+```php
+class MyCustomClass implements \DefStudio\Telegraph\Contracts\Storable{
+    use \DefStudio\Telegraph\Concerns\HasStorage;
+    
+    public function storageKey(): string|int
+    {
+        return "MyCustomClass instance unique ID";
+    }
+}
+```
 
 ### Bot Storage
 
@@ -132,4 +145,18 @@ value inside Laravel Redis Cache
 
 ```php
 $telegraphUser->storage('cache')->put('name', 'Daniele');
+```
+
+
+## Storing models
+
+Telegraph can store model references as well: when a model is found inside data stored, it is internally converted in a class/id pair and the model is retrieved from DB when the value is fetched:
+
+```php
+/** @var \DefStudio\Telegraph\DTO\User $telegraphUser */
+$systemUser = \App\Models\User::where('username', $telegraphUser->username());
+
+$telegraphUser->storage()->set('system_data.user', $systemUser);
+
+$telegraphUser->storage()->get('system_data.user') // will return an Instance of \App\Models\User 
 ```

--- a/src/Storage/CacheStorageDriver.php
+++ b/src/Storage/CacheStorageDriver.php
@@ -34,13 +34,13 @@ class CacheStorageDriver extends StorageDriver
             return;
         }
 
-        $mainKey = Str::of($key)->before('.');
-        $mainValue = $this->retrieveData($mainKey->toString(), []);
+        $mainKey = (string)Str::of($key)->before('.');
+        $mainValue = $this->retrieveData($mainKey, []);
 
-        $otherKeys = Str::of($key)->after('.');
-        data_set($mainValue, $otherKeys->toString(), $value);
+        $otherKeys = (string)Str::of($key)->after('.');
+        data_set($mainValue, $otherKeys, $value);
 
-        $this->cache->set("{$this->key}_".$mainKey->toString(), $mainValue);
+        $this->cache->set("{$this->key}_".$mainKey, $mainValue);
     }
 
     public function retrieveData(string $key, mixed $default = null): mixed
@@ -49,12 +49,12 @@ class CacheStorageDriver extends StorageDriver
             return $this->cache->get("{$this->key}_$key", $default);
         }
 
-        $mainKey = Str::of($key)->before('.');
-        $mainValue = $this->retrieveData($mainKey->toString(), []);
+        $mainKey = (string) Str::of($key)->before('.');
+        $mainValue = $this->retrieveData($mainKey, []);
 
-        $otherKeys = Str::of($key)->after('.');
+        $otherKeys = (string) Str::of($key)->after('.');
 
-        return data_get($mainValue, $otherKeys->toString(), $default);
+        return data_get($mainValue, $otherKeys, $default);
     }
 
     public function forget(string $key): static
@@ -63,10 +63,10 @@ class CacheStorageDriver extends StorageDriver
             $this->cache->forget("{$this->key}_$key");
         }
 
-        $mainKey = Str::of($key)->before('.');
-        $mainValue = $this->retrieveData($mainKey->toString(), []);
+        $mainKey = (string) Str::of($key)->before('.');
+        $mainValue = $this->retrieveData($mainKey, []);
 
-        $otherKeys = Str::of($key)->after('.');
+        $otherKeys = (string) Str::of($key)->after('.');
 
         Arr::forget($mainValue, $otherKeys);
 

--- a/src/Storage/CacheStorageDriver.php
+++ b/src/Storage/CacheStorageDriver.php
@@ -4,12 +4,11 @@
 
 namespace DefStudio\Telegraph\Storage;
 
-use DefStudio\Telegraph\Contracts\StorageDriver;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
-class CacheStorageDriver implements StorageDriver
+class CacheStorageDriver extends StorageDriver
 {
     private string $key;
     private Repository $cache;
@@ -26,14 +25,12 @@ class CacheStorageDriver implements StorageDriver
         $this->cache = Cache::store($configuration['store'] ?? null);
     }
 
-    public function set(string $key, mixed $value): static
+    public function storeData(string $key, mixed $value): void
     {
         $this->cache->set("{$this->key}_$key", $value);
-
-        return $this;
     }
 
-    public function get(string $key, mixed $default = null): mixed
+    public function retrieveData(string $key, mixed $default = null): mixed
     {
         return $this->cache->get("{$this->key}_$key", $default);
     }

--- a/src/Storage/FileStorageDriver.php
+++ b/src/Storage/FileStorageDriver.php
@@ -2,6 +2,7 @@
 
 namespace DefStudio\Telegraph\Storage;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
@@ -36,7 +37,7 @@ class FileStorageDriver extends StorageDriver
 
             /** @phpstan-ignore-next-line */
             return rescue(fn () => json_decode($json, true, flags: JSON_THROW_ON_ERROR), []);
-        } catch (JsonException) {
+        } catch (JsonException|FileNotFoundException) {
             return [];
         }
     }

--- a/src/Storage/FileStorageDriver.php
+++ b/src/Storage/FileStorageDriver.php
@@ -2,15 +2,13 @@
 
 namespace DefStudio\Telegraph\Storage;
 
-use DefStudio\Telegraph\Contracts\StorageDriver;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use JsonException;
 
-class FileStorageDriver implements StorageDriver
+class FileStorageDriver extends StorageDriver
 {
     private string $file;
 
@@ -31,14 +29,14 @@ class FileStorageDriver implements StorageDriver
     /**
      * @return array<array-key, mixed>
      */
-    private function getData(): array
+    private function getDataFromJson(): array
     {
         try {
             $json = $this->disk->get($this->file);
 
             /** @phpstan-ignore-next-line */
             return rescue(fn () => json_decode($json, true, flags: JSON_THROW_ON_ERROR), []);
-        } catch (FileNotFoundException|JsonException) {
+        } catch (JsonException) {
             return [];
         }
     }
@@ -46,7 +44,7 @@ class FileStorageDriver implements StorageDriver
     /**
      * @param array<array-key, mixed> $data
      */
-    private function storeData(array $data): void
+    private function storeDataInJson(array $data): void
     {
         $json = json_encode($data);
 
@@ -54,27 +52,25 @@ class FileStorageDriver implements StorageDriver
         $this->disk->put($this->file, $json);
     }
 
-    public function set(string $key, mixed $value): static
+    public function storeData(string $key, mixed $value): void
     {
-        $data = $this->getData();
+        $data = $this->getDataFromJson();
         Arr::set($data, $key, $value);
-        $this->storeData($data);
-
-        return $this;
+        $this->storeDataInJson($data);
     }
 
-    public function get(string $key, mixed $default = null): mixed
+    public function retrieveData(string $key, mixed $default = null): mixed
     {
-        $data = $this->getData();
+        $data = $this->getDataFromJson();
 
         return Arr::get($data, $key, $default);
     }
 
     public function forget(string $key): static
     {
-        $data = $this->getData();
+        $data = $this->getDataFromJson();
         Arr::forget($data, $key);
-        $this->storeData($data);
+        $this->storeDataInJson($data);
 
         return $this;
     }

--- a/src/Storage/StorageDriver.php
+++ b/src/Storage/StorageDriver.php
@@ -12,6 +12,7 @@ abstract class StorageDriver implements \DefStudio\Telegraph\Contracts\StorageDr
     final public function set(string $key, mixed $value): static
     {
         $this->storeData($key, $this->dehydrate($value));
+
         return $this;
     }
 
@@ -45,6 +46,7 @@ abstract class StorageDriver implements \DefStudio\Telegraph\Contracts\StorageDr
         if (is_array($value)) {
             if (array_key_exists(self::MODEL_CLASS_KEY, $value)) {
                 $modelClass = $value[self::MODEL_CLASS_KEY];
+
                 return $modelClass::find($value[self::MODEL_ID_KEY]);
             }
 

--- a/src/Storage/StorageDriver.php
+++ b/src/Storage/StorageDriver.php
@@ -57,7 +57,7 @@ abstract class StorageDriver implements \DefStudio\Telegraph\Contracts\StorageDr
                 return $modelClass::find($collection->get(self::MODEL_ID_KEY));
             }
 
-            return $collection->map(fn ($item) => $this->hydrate($item))->toArray();
+            return array_map(fn ($item) => $this->hydrate($item), $collection->toArray());
         }
 
         return $value;

--- a/src/Storage/StorageDriver.php
+++ b/src/Storage/StorageDriver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DefStudio\Telegraph\Storage;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class StorageDriver implements \DefStudio\Telegraph\Contracts\StorageDriver
+{
+    private const MODEL_CLASS_KEY = ':tgph_model_class:';
+    private const MODEL_ID_KEY = ':tgph_model_id:';
+
+    final public function set(string $key, mixed $value): static
+    {
+        $this->storeData($key, $this->dehydrate($value));
+        return $this;
+    }
+
+    final public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->hydrate($this->retrieveData($key, $default));
+    }
+
+    abstract protected function storeData(string $key, mixed $value): void;
+
+    abstract protected function retrieveData(string $key, mixed $default): mixed;
+
+    private function hydrate(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->hydrate($item), $value);
+        }
+
+        if ($value instanceof Model) {
+            return [
+                self::MODEL_CLASS_KEY => $value::class,
+                self::MODEL_ID_KEY => $value->id,
+            ];
+        }
+
+        return $value;
+    }
+
+    private function dehydrate(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            if (array_key_exists(self::MODEL_CLASS_KEY, $value)) {
+                $modelClass = $value[self::MODEL_CLASS_KEY];
+                return $modelClass::find($value[self::MODEL_ID_KEY]);
+            }
+
+            return array_map(fn ($item) => $this->dehydrate($item), $value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Unit/Storage/CacheStoreDriverTest.php
+++ b/tests/Unit/Storage/CacheStoreDriverTest.php
@@ -2,9 +2,9 @@
 
 use DefStudio\Telegraph\Concerns\HasStorage;
 use DefStudio\Telegraph\Contracts\Storable;
-use Illuminate\Support\Str;
+use DefStudio\Telegraph\Models\TelegraphChat;
 
-it('can store and retrieve data data', function (string $key, mixed $value) {
+it('can store and retrieve data', function (string $key, mixed $value) {
     $class = new class () implements Storable {
         use HasStorage;
 
@@ -14,14 +14,8 @@ it('can store and retrieve data data', function (string $key, mixed $value) {
         }
     };
 
-    config()->set('cache.default', 'file');
     $class->storage('cache')->set($key, $value);
 
-    $cacheKey = Str::of('tgph')
-        ->append("_", class_basename($class::class))
-        ->append("_", 'foo');
-
-    expect(Cache::get("{$cacheKey}_$key"))->toBe($value);
     expect($class->storage('cache')->get($key))->toBe($value);
 
     $class->storage('cache')->forget($key);
@@ -33,3 +27,45 @@ it('can store and retrieve data data', function (string $key, mixed $value) {
     'bool' => ['key' => 'foo.bar', 'value' => true],
     'array' => ['key' => 'foo.bar', 'value' => ['baz', 'qux']],
 ]);
+
+
+it('can store and retrieve a model', function () {
+    $class = new class () implements Storable {
+        use HasStorage;
+
+        public function storageKey(): string
+        {
+            return 'foo';
+        }
+    };
+
+    $model = TelegraphChat::factory()->create();
+
+    $class->storage('cache')->set('model', $model);
+
+    expect($class->storage('cache')->get('model'))
+        ->toBeInstanceOf(TelegraphChat::class)
+        ->id->toBe($model->id);
+});
+
+it('can store and retrieve a nested model', function () {
+    $class = new class () implements Storable {
+        use HasStorage;
+
+        public function storageKey(): string
+        {
+            return 'foo';
+        }
+    };
+
+    $models = TelegraphChat::factory()->count(4)->create();
+
+    $class->storage('cache')->set('models', $models);
+
+
+    expect($class->storage('cache'))
+        ->get('models.0')->id->toBe(1)
+        ->get('models.1')->id->toBe(2)
+        ->get('models.2')->id->toBe(3)
+        ->get('models.3')->id->toBe(4);
+});

--- a/tests/Unit/Storage/CacheStoreDriverTest.php
+++ b/tests/Unit/Storage/CacheStoreDriverTest.php
@@ -63,9 +63,8 @@ it('can store and retrieve a nested model', function () {
     $class->storage('cache')->set('models', $models);
 
 
-    expect($class->storage('cache'))
-        ->get('models.0')->id->toBe(1)
-        ->get('models.1')->id->toBe(2)
-        ->get('models.2')->id->toBe(3)
-        ->get('models.3')->id->toBe(4);
+    expect($class->storage('cache')->get('models.0'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(1);
+    expect($class->storage('cache')->get('models.1'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(2);
+    expect($class->storage('cache')->get('models.2'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(3);
+    expect($class->storage('cache')->get('models.3'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(4);
 });

--- a/tests/Unit/Storage/FileStoreDriverTest.php
+++ b/tests/Unit/Storage/FileStoreDriverTest.php
@@ -115,9 +115,8 @@ it('can store and retrieve a nested model', function () {
         ],
     ]);
 
-    expect($class->storage('file'))
-        ->get('models.0')->id->toBe(1)
-        ->get('models.1')->id->toBe(2)
-        ->get('models.2')->id->toBe(3)
-        ->get('models.3')->id->toBe(4);
+    expect($class->storage('file')->get('models.0'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(1);
+    expect($class->storage('file')->get('models.1'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(2);
+    expect($class->storage('file')->get('models.2'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(3);
+    expect($class->storage('file')->get('models.3'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(4);
 });

--- a/tests/Unit/Storage/FileStoreDriverTest.php
+++ b/tests/Unit/Storage/FileStoreDriverTest.php
@@ -2,13 +2,14 @@
 
 use DefStudio\Telegraph\Concerns\HasStorage;
 use DefStudio\Telegraph\Contracts\Storable;
+use DefStudio\Telegraph\Models\TelegraphChat;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
     Storage::fake();
 });
 
-it('can store and retrieve data data', function (string $key, mixed $value) {
+it('can store and retrieve data', function (string $key, mixed $value) {
     $class = new class () implements Storable {
         use HasStorage;
 
@@ -26,7 +27,7 @@ it('can store and retrieve data data', function (string $key, mixed $value) {
 
     expect(Storage::exists($file))->toBeTrue();
 
-    $data = json_decode(Storage::get($file));
+    $data = json_decode(Storage::get($file), true);
     expect(data_get($data, $key))->toBe($value);
 
     expect($class->storage('file')->get($key))->toBe($value);
@@ -40,3 +41,83 @@ it('can store and retrieve data data', function (string $key, mixed $value) {
     'bool' => ['key' => 'foo.bar', 'value' => true],
     'array' => ['key' => 'foo.bar', 'value' => ['baz', 'qux']],
 ]);
+
+it('can store and retrieve a model', function () {
+    $class = new class () implements Storable {
+        use HasStorage;
+
+        public function storageKey(): string
+        {
+            return 'foo';
+        }
+    };
+
+    $model = TelegraphChat::factory()->create();
+
+    $class->storage('file')->set('model', $model);
+
+    $file = Str::of('telegraph')
+        ->append('/', class_basename($class::class))
+        ->append("/", 'foo', '.json');
+
+    expect(Storage::exists($file))->toBeTrue();
+
+    $data = json_decode(Storage::get($file), true);
+
+    expect(data_get($data, 'model'))->toBe([
+        ':tgph_model_class:' => TelegraphChat::class,
+        ':tgph_model_id:' => $model->id,
+    ]);
+
+    expect($class->storage('file')->get('model'))
+        ->toBeInstanceOf(TelegraphChat::class)
+        ->id->toBe($model->id);
+});
+
+it('can store and retrieve a nested model', function () {
+    $class = new class () implements Storable {
+        use HasStorage;
+
+        public function storageKey(): string
+        {
+            return 'foo';
+        }
+    };
+
+    $models = TelegraphChat::factory()->count(4)->create();
+
+    $class->storage('file')->set('models', $models);
+
+    $file = Str::of('telegraph')
+        ->append('/', class_basename($class::class))
+        ->append("/", 'foo', '.json');
+
+    expect(Storage::exists($file))->toBeTrue();
+
+    $data = json_decode(Storage::get($file), true);
+
+    expect(data_get($data, 'models'))->toBe([
+        [
+            ':tgph_model_class:' => TelegraphChat::class,
+            ':tgph_model_id:' => 1,
+        ],
+        [
+            ':tgph_model_class:' => TelegraphChat::class,
+            ':tgph_model_id:' => 2,
+        ],
+        [
+            ':tgph_model_class:' => TelegraphChat::class,
+            ':tgph_model_id:' => 3,
+        ],
+        [
+            ':tgph_model_class:' => TelegraphChat::class,
+            ':tgph_model_id:' => 4,
+        ],
+    ]);
+
+    expect($class->storage('file'))
+        ->get('models.0')->id->toBe(1)
+        ->get('models.1')->id->toBe(2)
+        ->get('models.2')->id->toBe(3)
+        ->get('models.3')->id->toBe(4);
+});


### PR DESCRIPTION
## Storing models

Telegraph can store model references as well: when a model is found inside data stored, it is internally converted in a class/id pair and the model is retrieved from DB when the value is fetched:

```php
/** @var \DefStudio\Telegraph\DTO\User $telegraphUser */
$systemUser = \App\Models\User::where('username', $telegraphUser->username());

$telegraphUser->storage()->set('system_data.user', $systemUser);

$telegraphUser->storage()->get('system_data.user') // will return an Instance of \App\Models\User 
```