### PR TITLE
[fix] disable telegraph facade caching

### DIFF
--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -81,6 +81,8 @@ use Illuminate\Support\Facades\Facade;
  */
 class Telegraph extends Facade
 {
+    protected static $cached = false;
+
     /**
      * @param array<string, array<mixed>> $replies
      */


### PR DESCRIPTION
fix #278 with the attribute cached as false, the resolvedInstance is no longer maintained