### PR TITLE
[fix] chat_ids greater than 2147483647 in 32 bit systems

### DIFF
--- a/src/DTO/Chat.php
+++ b/src/DTO/Chat.php
@@ -14,7 +14,7 @@ class Chat implements Arrayable
     public const TYPE_SUPERGROUP = 'supergroup';
     public const TYPE_CHANNEL = 'channel';
 
-    private int $id;
+    private string $id;
     private string $type;
     private string $title;
 
@@ -23,7 +23,7 @@ class Chat implements Arrayable
     }
 
     /**
-     * @param array{id:int, type:string, title?:string, username?: string} $data
+     * @param array{id:string, type:string, title?:string, username?: string} $data
      */
     public static function fromArray(array $data): Chat
     {
@@ -36,7 +36,7 @@ class Chat implements Arrayable
         return $chat;
     }
 
-    public function id(): int
+    public function id(): string
     {
         return $this->id;
     }

--- a/tests/__snapshots__/TelegraphBotTest__it_can_poll_for_updates__1.yml
+++ b/tests/__snapshots__/TelegraphBotTest__it_can_poll_for_updates__1.yml
@@ -1,6 +1,6 @@
 -
     id: 123456
-    message: { id: 42, date: '2022-03-05T21:45:36.000000Z', text: /start, from: { id: 444, first_name: John, last_name: Smith, username: john_smith }, chat: { id: 987654, type: private, title: john_smith } }
+    message: { id: 42, date: '2022-03-05T21:45:36.000000Z', text: /start, from: { id: 444, first_name: John, last_name: Smith, username: john_smith }, chat: { id: '987654', type: private, title: john_smith } }
 -
     id: 123457
-    message: { id: 99, date: '2022-03-05T22:35:36.000000Z', text: 'Hello world!', from: { id: 8974, is_bot: true, first_name: 'Test Bot', username: test_bot }, chat: { id: -987455499, type: group, title: 'Bot Test Chat' } }
+    message: { id: 99, date: '2022-03-05T22:35:36.000000Z', text: 'Hello world!', from: { id: 8974, is_bot: true, first_name: 'Test Bot', username: test_bot }, chat: { id: '-987455499', type: group, title: 'Bot Test Chat' } }


### PR DESCRIPTION
An integer data type is a non-decimal number between **-2147483648** and **2147483647** in 32 bit systems.
Currently, Telegram assigns _chat_ids_ greater than **2147483647** to new accounts, so they cannot be treated as `int` data by PHP without being distorted in 32 bit systems.
Using the `string` data type instead of `int` to handle the _chat_id_ could be a work around to this limitation and solve this issue  #284 