### PR TITLE
[feat] Model-less mode

### DIFF
--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -132,7 +132,7 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_PIN_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
             'message_id' => $messageId,
         ];
 
@@ -145,7 +145,7 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_UNPIN_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
             'message_id' => $messageId,
         ];
 
@@ -158,7 +158,7 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_UNPIN_ALL_MESSAGES;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
         ];
 
         return $telegraph;
@@ -172,7 +172,7 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_FORWARD_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
             'message_id' => $messageId,
             'from_chat_id' => $fromChatId,
         ];

--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -25,7 +25,7 @@ trait ComposesMessages
         $this->endpoint ??= self::ENDPOINT_MESSAGE;
 
         $this->data['text'] = $message;
-        $this->data['chat_id'] = $this->getChat()->chat_id;
+        $this->data['chat_id'] = $this->getChatId();
     }
 
     public function html(string $message = null): Telegraph
@@ -119,7 +119,7 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
             'message_id' => $messageId,
         ];
 

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -113,7 +113,7 @@ trait HasBotsAndChats
     {
         $chat = $this->getChat();
 
-        if($chat instanceof TelegraphChat){
+        if ($chat instanceof TelegraphChat) {
             return $chat->chat_id;
         }
 

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -62,7 +62,7 @@ trait HasBotsAndChats
 
         if (empty($telegraph->bot)) {
             /** @var TelegraphBot|string $bot */
-            $bot = rescue(fn () => TelegraphBot::query()->with('chats')->sole(), config('telegraph.bot_id'), false);
+            $bot = rescue(fn () => TelegraphBot::query()->with('chats')->sole(), config('telegraph.bot_token'), false);
 
             $telegraph->bot = $bot;
         }

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -72,9 +72,18 @@ trait HasBotsAndChats
 
     protected function getBot(): TelegraphBot|string
     {
-        $telegraph = clone $this;
+        return $this->getBotIfAvailable() ?? throw TelegraphException::missingBot();
+    }
 
-        return $telegraph->getBotIfAvailable() ?? throw TelegraphException::missingBot();
+    protected function getBotToken(): string
+    {
+        $bot = $this->getBot();
+
+        if ($bot instanceof TelegraphBot) {
+            return $bot->token;
+        }
+
+        return $bot;
     }
 
     protected function getChatIfAvailable(): TelegraphChat|string|null
@@ -86,7 +95,7 @@ trait HasBotsAndChats
 
             if ($bot instanceof TelegraphBot) {
                 /** @var TelegraphChat|string $chat */
-                $chat = rescue(fn () => $bot?->chats()->sole(), config('telegraph.chat_id'), false);
+                $chat = rescue(fn () => $bot->chats()->sole(), config('telegraph.chat_id'), false);
 
                 $telegraph->chat = $chat;
             }
@@ -104,9 +113,7 @@ trait HasBotsAndChats
 
     protected function getChat(): TelegraphChat|string
     {
-        $telegraph = clone $this;
-
-        return $telegraph->getChatIfAvailable() ?? throw TelegraphException::missingChat();
+        return $this->getChatIfAvailable() ?? throw TelegraphException::missingChat();
     }
 
     protected function getChatId(): string
@@ -125,7 +132,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_LEAVE_CHAT;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -195,7 +202,7 @@ trait HasBotsAndChats
         in_array($action, ChatActions::available_actions()) || throw TelegraphException::invalidChatAction($action);
 
         $telegraph->endpoint = self::ENDPOINT_SEND_CHAT_ACTION;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['action'] = $action;
 
         return $telegraph;
@@ -209,7 +216,7 @@ trait HasBotsAndChats
         strlen($title) < 256 || throw ChatSettingsException::titleMaxLengthExceeded();
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_TITLE;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['title'] = $title;
 
         return $telegraph;
@@ -222,7 +229,7 @@ trait HasBotsAndChats
         strlen($description) < 256 || throw ChatSettingsException::descriptionMaxLengthExceeded();
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_DESCRIPTION;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['description'] = $description;
 
         return $telegraph;
@@ -233,7 +240,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_PHOTO;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         File::exists($path) || throw FileException::fileNotFound('photo', $path);
 
@@ -262,7 +269,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_CHAT_PHOTO;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -272,7 +279,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_INFO;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -291,7 +298,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_EXPORT_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -301,7 +308,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_CREATE_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -347,7 +354,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_EDIT_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['invite_link'] = $link;
 
         return $telegraph;
@@ -358,7 +365,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_REVOKE_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['invite_link'] = $link;
 
         return $telegraph;
@@ -369,7 +376,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_MEMBER_COUNT;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -379,7 +386,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;
@@ -393,7 +400,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_PERMISSIONS;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         $permissions = collect($permissions)
             ->mapWithKeys(
@@ -412,7 +419,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_BAN_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;
@@ -441,7 +448,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_UNBAN_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
         $telegraph->data['only_if_banned'] = true;
 
@@ -456,7 +463,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_RESTRICT_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
 
         /** @var array<string, bool> $permissions */
@@ -481,7 +488,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_PROMOTE_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
 
         /** @var array<string, bool> $permissions */
@@ -504,7 +511,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_PROMOTE_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['user_id'] = $userId;
 
         $permissions = collect(ChatAdminPermissions::available_permissions())

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -109,6 +109,17 @@ trait HasBotsAndChats
         return $telegraph->getChatIfAvailable() ?? throw TelegraphException::missingChat();
     }
 
+    protected function getChatId(): string
+    {
+        $chat = $this->getChat();
+
+        if($chat instanceof TelegraphChat){
+            return $chat->chat_id;
+        }
+
+        return $chat;
+    }
+
     public function leaveChat(): Telegraph
     {
         $telegraph = clone $this;

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -103,7 +103,7 @@ trait InteractsWithTelegram
     {
         /** @phpstan-ignore-next-line */
         return (string) Str::of($this->getBaseUrl())
-            ->append($this->getBot()->token)
+            ->append($this->getBotToken())
             ->append('/', $this->endpoint)
             ->when(!empty($this->data), fn (Stringable $str) => $str->append('?', http_build_query($this->data)));
     }
@@ -112,7 +112,7 @@ trait InteractsWithTelegram
     {
         /** @phpstan-ignore-next-line */
         return (string) Str::of($this->getBaseUrl())
-            ->append($this->getBot()->token)
+            ->append($this->getBotToken())
             ->append('/', $this->endpoint);
     }
 

--- a/src/Concerns/ManagesKeyboards.php
+++ b/src/Concerns/ManagesKeyboards.php
@@ -110,7 +110,7 @@ trait ManagesKeyboards
 
         $telegraph->endpoint = self::ENDPOINT_REPLACE_KEYBOARD;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChat()->chat_id,
+            'chat_id' => $telegraph->getChatId(),
             'message_id' => $messageId,
             'reply_markup' => $replyMarkup,
         ];

--- a/src/Concerns/SendsAttachments.php
+++ b/src/Concerns/SendsAttachments.php
@@ -59,7 +59,7 @@ trait SendsAttachments
 
         $telegraph->endpoint = self::ENDPOINT_EDIT_MEDIA;
 
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['message_id'] = $messageId;
 
         return TelegraphEditMediaPayload::makeFrom($telegraph);
@@ -72,7 +72,7 @@ trait SendsAttachments
         $telegraph->endpoint = self::ENDPOINT_SEND_LOCATION;
         $telegraph->data['latitude'] = $latitude;
         $telegraph->data['longitude'] = $longitude;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         return $telegraph;
     }
@@ -83,7 +83,7 @@ trait SendsAttachments
 
         $telegraph->endpoint = self::ENDPOINT_SEND_VOICE;
 
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         if (File::exists($path)) {
             $telegraph->files->put('voice', new Attachment($path, $filename));
@@ -103,7 +103,7 @@ trait SendsAttachments
 
         $telegraph->endpoint = self::ENDPOINT_SEND_DOCUMENT;
 
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
 
         $this->attachDocument($telegraph, $path, $filename);
@@ -158,7 +158,7 @@ trait SendsAttachments
 
         $telegraph->endpoint = self::ENDPOINT_SEND_PHOTO;
 
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         $this->attachPhoto($telegraph, $path, $filename);
 
@@ -209,7 +209,7 @@ trait SendsAttachments
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_DICE;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
 
         if ($emoji !== null) {
             $telegraph->data['emoji'] = $emoji;

--- a/src/Concerns/StoresFiles.php
+++ b/src/Concerns/StoresFiles.php
@@ -36,7 +36,7 @@ trait StoresFiles
         $filePath = $response->json('result.file_path');
 
         $url = Str::of($this->getFilesBaseUrl())
-            ->append($this->getBot()->token)
+            ->append($this->getBotToken())
             ->append('/', $filePath);
 
         $response = Http::get($url);

--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -13,8 +13,8 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static string getUrl()
- * @method static \DefStudio\Telegraph\Telegraph  bot(TelegraphBot $bot)
- * @method static \DefStudio\Telegraph\Telegraph  chat(TelegraphChat $chat)
+ * @method static \DefStudio\Telegraph\Telegraph  bot(TelegraphBot|string $bot)
+ * @method static \DefStudio\Telegraph\Telegraph  chat(TelegraphChat|string $chat)
  * @method static \DefStudio\Telegraph\Telegraph  message(string $message)
  * @method static \DefStudio\Telegraph\Telegraph  html(string $message)
  * @method static \DefStudio\Telegraph\Telegraph  reply(int $messageId)

--- a/src/ScopedPayloads/TelegraphPollPayload.php
+++ b/src/ScopedPayloads/TelegraphPollPayload.php
@@ -18,7 +18,7 @@ class TelegraphPollPayload extends Telegraph
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SEND_POLL;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['options'] = [];
         $telegraph->data['question'] = $question;
 

--- a/src/ScopedPayloads/TelegraphQuizPayload.php
+++ b/src/ScopedPayloads/TelegraphQuizPayload.php
@@ -21,7 +21,7 @@ class TelegraphQuizPayload extends Telegraph
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SEND_POLL;
-        $telegraph->data['chat_id'] = $telegraph->getChat()->chat_id;
+        $telegraph->data['chat_id'] = $telegraph->getChatId();
         $telegraph->data['type'] = 'quiz';
         $telegraph->data['options'] = [];
         $telegraph->data['question'] = $question;

--- a/tests/Unit/Concerns/HasBotsAndChatsTest.php
+++ b/tests/Unit/Concerns/HasBotsAndChatsTest.php
@@ -25,9 +25,25 @@ it('can customize the destination bot', function () {
     expect($telegraph->getApiUrl())->toStartWith("https://api.telegram.org/bot$bot->token/");
 });
 
+it('can customize the destination bot through its token', function () {
+    withfakeUrl();
+
+    $telegraph = Telegraph::bot('TOKEN')
+        ->registerWebhook();
+
+    expect($telegraph->getApiUrl())->toStartWith("https://api.telegram.org/botTOKEN/");
+});
+
 it('can customize the destination chat', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
         return $telegraph->chat(make_chat())
+            ->html('foobar');
+    })->toMatchTelegramSnapshot();
+});
+
+it('can customize the destination chat through its ID', function () {
+    expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
+        return $telegraph->chat("123456789")
             ->html('foobar');
     })->toMatchTelegramSnapshot();
 });
@@ -40,9 +56,24 @@ it('can retrieve bot info', function () {
     assertMatchesSnapshot($response->json('result'));
 });
 
+it('can retrieve bot info from its token', function () {
+    Telegraph::fake();
+    $response = Telegraph::bot("3f3814e1-5836-3d77-904e-60f64b15df36")->botInfo()->send();
+    assertMatchesSnapshot($response->json('result'));
+});
+
 it('can register commands', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
         return $telegraph->bot(make_bot())->registerBotCommands([
+            'foo' => 'first command',
+            'bar' => 'second command',
+        ]);
+    })->toMatchTelegramSnapshot();
+});
+
+it('can register commands with token', function () {
+    expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
+        return $telegraph->bot("3f3814e1-5836-3d77-904e-60f64b15df36")->registerBotCommands([
             'foo' => 'first command',
             'bar' => 'second command',
         ]);
@@ -69,7 +100,7 @@ it('can send a chat action', function () {
 
 it('can change chat title', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
-        return $telegraph->chat(make_chat())->setTitle('foo');
+        return $telegraph->chat("-123456789")->setTitle('foo');
     })->toMatchTelegramSnapshot();
 });
 

--- a/tests/__snapshots__/HasBotsAndChatsTest__it_can_customize_the_destination_chat_through_its_ID__1.yml
+++ b/tests/__snapshots__/HasBotsAndChatsTest__it_can_customize_the_destination_chat_through_its_ID__1.yml
@@ -1,0 +1,6 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/sendMessage'
+payload:
+    text: foobar
+    chat_id: '123456789'
+    parse_mode: html
+files: {  }

--- a/tests/__snapshots__/HasBotsAndChatsTest__it_can_register_commands_with_token__1.yml
+++ b/tests/__snapshots__/HasBotsAndChatsTest__it_can_register_commands_with_token__1.yml
@@ -1,0 +1,4 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/setMyCommands'
+payload:
+    commands: [{ command: foo, description: 'first command' }, { command: bar, description: 'second command' }]
+files: {  }

--- a/tests/__snapshots__/HasBotsAndChatsTest__it_can_retrieve_bot_info_from_its_token__1.yml
+++ b/tests/__snapshots__/HasBotsAndChatsTest__it_can_retrieve_bot_info_from_its_token__1.yml
@@ -1,0 +1,7 @@
+id: 42
+is_bot: true
+first_name: telegraph-test
+username: test_bot
+can_join_groups: true
+can_read_all_group_messages: false
+supports_inline_queries: false


### PR DESCRIPTION
this PR will enable the usage of telegraph without the need to create a TelegraphBot/TelegraphChat model, useful for simple projects

the bot/chat pair can both be set for each call:

`Telegraph::bot('TOKEN')->chat('ID')->message('hello')->send()`

and in configuration with `telegraph.bot_token` and `telegraph.chat_id`

ref #290 