### PR TITLE
[fix] drop updates option missing in UnsetTelegramWebhookCommand

### DIFF
--- a/src/Commands/UnsetTelegramWebhookCommand.php
+++ b/src/Commands/UnsetTelegramWebhookCommand.php
@@ -9,7 +9,7 @@ class UnsetTelegramWebhookCommand extends Command
 {
     public $signature = 'telegraph:unset-webhook
                             {bot? : the ID of the bot (if the system contain a single bot, it can be left empty)}
-                            {--drop-pending-updates: if set, upon webhook deletion, all pending updates will be discarded}';
+                            {--drop-pending-updates : if set, upon webhook deletion, all pending updates will be discarded}';
 
     public $description = 'Unregister the webhook in telegram bot configuration';
 

--- a/tests/Feature/Commands/UnsetTelegramWebhookCommandTest.php
+++ b/tests/Feature/Commands/UnsetTelegramWebhookCommandTest.php
@@ -10,13 +10,24 @@ use Symfony\Component\Console\Command\Command;
 
 uses(LazilyRefreshDatabase::class);
 
-test('can set telegram webhook address if there is only one', function () {
+test('can unset a telegram webhook', function () {
     bot();
 
     Telegraph::fake();
 
     /** @phpstan-ignore-next-line */
     artisan('telegraph:unset-webhook')
+        ->expectsOutput("Webhook deleted")
+        ->assertExitCode(Command::SUCCESS);
+});
+
+test('can unset a telegram webhook and drop pending updates', function () {
+    bot();
+
+    Telegraph::fake();
+
+    /** @phpstan-ignore-next-line */
+    artisan('telegraph:unset-webhook --drop-pending-updates')
         ->expectsOutput("Webhook deleted")
         ->assertExitCode(Command::SUCCESS);
 });


### PR DESCRIPTION
Fixes #321, there was a missing space between option name and its description