### PR TITLE
Added user parameter: "language_code"

### DIFF
--- a/src/DTO/User.php
+++ b/src/DTO/User.php
@@ -17,13 +17,14 @@ class User implements Arrayable, Storable
     private string $firstName;
     private string $lastName;
     private string $username;
+    private string $languageCode;
 
     private function __construct()
     {
     }
 
     /**
-     * @param array{id:int, is_bot:bool, first_name?:string, last_name?:string, username?:string} $data
+     * @param array{id:int, is_bot:bool, first_name?:string, last_name?:string, username?:string, language_code?:string} $data
      */
     public static function fromArray(array $data): User
     {
@@ -35,6 +36,7 @@ class User implements Arrayable, Storable
         $user->firstName = $data['first_name'] ?? '';
         $user->lastName = $data['last_name'] ?? '';
         $user->username = $data['username'] ?? '';
+        $user->languageCode = $data['language_code'] ?? '';
 
         return $user;
     }
@@ -69,6 +71,11 @@ class User implements Arrayable, Storable
         return $this->username;
     }
 
+    public function languageCode(): string
+    {
+        return $this->languageCode;
+    }
+
     public function toArray(): array
     {
         return array_filter([
@@ -77,6 +84,7 @@ class User implements Arrayable, Storable
             'first_name' => $this->firstName,
             'last_name' => $this->lastName,
             'username' => $this->username,
+            'language_code' => $this->languageCode,
         ]);
     }
 }

--- a/tests/Unit/DTO/MessageTest.php
+++ b/tests/Unit/DTO/MessageTest.php
@@ -19,6 +19,7 @@ it('export all properties to array', function () {
             'first_name' => 'a',
             'last_name' => 'b',
             'username' => 'c',
+            'language_code' => 'd',
         ],
         'forward_from' => [
             'id' => 1,

--- a/tests/Unit/DTO/UserTest.php
+++ b/tests/Unit/DTO/UserTest.php
@@ -12,6 +12,7 @@ it('export all properties to array', function () {
         'first_name' => 'a',
         'last_name' => 'b',
         'username' => 'c',
+        'language_code' => 'd',
     ]);
 
     $array = $dto->toArray();

--- a/tests/__snapshots__/TelegraphBotTest__it_can_poll_for_updates__1.yml
+++ b/tests/__snapshots__/TelegraphBotTest__it_can_poll_for_updates__1.yml
@@ -1,6 +1,6 @@
 -
     id: 123456
-    message: { id: 42, date: '2022-03-05T21:45:36.000000Z', text: /start, from: { id: 444, first_name: John, last_name: Smith, username: john_smith }, chat: { id: '987654', type: private, title: john_smith } }
+    message: { id: 42, date: '2022-03-05T21:45:36.000000Z', text: /start, from: { id: 444, first_name: John, last_name: Smith, username: john_smith, language_code: en }, chat: { id: '987654', type: private, title: john_smith } }
 -
     id: 123457
     message: { id: 99, date: '2022-03-05T22:35:36.000000Z', text: 'Hello world!', from: { id: 8974, is_bot: true, first_name: 'Test Bot', username: test_bot }, chat: { id: '-987455499', type: group, title: 'Bot Test Chat' } }


### PR DESCRIPTION
In some cases, Telegram sends the user's `language_code` key, and in some cases it doesn't.

I did not find the relationship from the settings, but this is a fact.

**Without key:**
```json
{
  "message": {
    "chat": {
      "id": 12345,
      "type": "supergroup",
      "title": "Some Group",
      "username": "some_group"
    },
    "date": 1677184219,
    "from": {
      "id": 123,
      "is_bot": false,
      "username": "foo",
      "first_name": "Foo"
    },
    "text": "Some text 1",
    "message_id": 925330
  },
  "update_id": 123456
}
```


**With key:**
```json
{
  "message": {
    "chat": {
      "id": 12345,
      "type": "supergroup",
      "title": "Some Group",
      "username": "some_group"
    },
    "date": 1677184343,
    "from": {
      "id": 234,
      "is_bot": false,
      "username": "bar",
      "first_name": "Bar",
      "language_code": "fr"
    },
    "text": "Some text 2",
    "message_id": 925331
  },
  "update_id": 123457
}
```