### PR TITLE
Feat: Add `rightToLeft` to `Keyboard` & `ReplyKeyboard`

### DIFF
--- a/docs/content/en/features/keyboards.md
+++ b/docs/content/en/features/keyboards.md
@@ -199,3 +199,22 @@ Keyboard::make()
     ->button('Dismiss')->action('dismiss')->param('id', '42')->width(0.5)
     ->when($userCanDelete, fn(Keyboard $keyboard) => $keyboard->button('Delete')->action('delete')->param('id', '42')->width(0.5))
 ```
+
+## Right to left layout
+
+A `rightToLeft` method allows to change buttons layout from left-to-right to right-to-left (RTL).
+
+```php
+use DefStudio\Telegraph\Keyboard\Button;
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+$keyboard = Keyboard::make()
+    ->row([
+        Button::make('Delete')->action('delete')->param('id', '42'),
+        Button::make('Dismiss')->action('dismiss')->param('id', '42'),
+    ])
+    ->row([
+        Button::make('open')->url('https://test.it'),
+    ])
+    ->rightToLeft();
+```

--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -12,6 +12,8 @@ class Keyboard implements Arrayable
     /** @var Collection<array-key, Button> */
     protected Collection $buttons;
 
+    protected bool $rtl = false;
+
     public function __construct()
     {
         /* @phpstan-ignore-next-line  */
@@ -31,6 +33,13 @@ class Keyboard implements Arrayable
         if ($condition) {
             return $callback($this);
         }
+
+        return $this;
+    }
+
+    public function rightToLeft(bool $condition = true): Keyboard
+    {
+        $this->rtl = $condition;
 
         return $this;
     }
@@ -222,6 +231,6 @@ class Keyboard implements Arrayable
 
         $keyboard[] = $row;
 
-        return $keyboard;
+        return $this->rtl ? array_map('array_reverse', $keyboard) : $keyboard;
     }
 }

--- a/src/Keyboard/ReplyKeyboard.php
+++ b/src/Keyboard/ReplyKeyboard.php
@@ -13,6 +13,7 @@ class ReplyKeyboard implements Arrayable
     /** @var Collection<array-key, ReplyButton> */
     protected Collection $buttons;
 
+    protected bool $rtl = false;
     protected bool $resize = false;
     protected bool $oneTime = false;
     protected bool $selective = false;
@@ -37,6 +38,13 @@ class ReplyKeyboard implements Arrayable
         if ($condition) {
             return $callback($this);
         }
+
+        return $this;
+    }
+
+    public function rightToLeft(bool $condition = true): self
+    {
+        $this->rtl = $condition;
 
         return $this;
     }
@@ -265,7 +273,7 @@ class ReplyKeyboard implements Arrayable
 
         $keyboard[] = $row;
 
-        return $keyboard;
+        return $this->rtl ? array_map('array_reverse', $keyboard) : $keyboard;
     }
 
     /**

--- a/tests/Unit/Keyboards/KeyboardTest.php
+++ b/tests/Unit/Keyboards/KeyboardTest.php
@@ -186,3 +186,28 @@ it('can handle conditional closures', function () {
         ],
     ]);
 });
+
+it('can right to left layout for buttons', function () {
+    $keyboard = Keyboard::make()
+        ->row([
+            Button::make('foo')->url('bar'),
+            Button::make('baz')->action('quuz'),
+        ])
+        ->row([
+            Button::make('baz')->action('quuz'),
+            Button::make('foo')->url('bar'),
+        ]);
+
+    $keyboard->rightToLeft();
+
+    expect($keyboard->toArray())->toMatchArray([
+        [
+            ['text' => 'baz', 'callback_data' => 'action:quuz'],
+            ['text' => 'foo', 'url' => 'bar'],
+        ],
+        [
+            ['text' => 'foo', 'url' => 'bar'],
+            ['text' => 'baz', 'callback_data' => 'action:quuz'],
+        ],
+    ]);
+});

--- a/tests/Unit/Keyboards/ReplyKeyboardTest.php
+++ b/tests/Unit/Keyboards/ReplyKeyboardTest.php
@@ -167,3 +167,30 @@ it('can handle conditional closures', function () {
         ],
     ]);
 });
+
+it('can right to left layout for buttons', function () {
+    $keyboard = ReplyKeyboard::make()
+        ->row([
+            ReplyButton::make('quzz')->requestLocation(),
+            ReplyButton::make('baz')->requestPoll(),
+            ReplyButton::make('foo'),
+        ])
+        ->row([
+            ReplyButton::make('foo'),
+            ReplyButton::make('baz')->requestLocation(),
+        ]);
+
+    $keyboard->rightToLeft();
+
+    expect($keyboard->toArray())->toMatchArray([
+        [
+            ['text' => 'foo'],
+            ['text' => 'baz', 'request_poll' => ['type' => 'regular']],
+            ['text' => 'quzz', 'request_location' => true],
+        ],
+        [
+            ['text' => 'baz', 'request_location' => true],
+            ['text' => 'foo'],
+        ],
+    ]);
+});


### PR DESCRIPTION
This pull request adds a new method called `rightToLeft` to the `Keyboard` and `ReplyKeyboard` classes. The `rightToLeft` method allows the user to flip the keyboard layout from left-to-right to right-to-left, and vice versa. This feature is particularly useful for languages that are written from right-to-left, such as Arabic, Persian, or Hebrew.