### PR TITLE
feat: configurable cache_tme for answerInlineQuery

### DIFF
--- a/config/telegraph.php
+++ b/config/telegraph.php
@@ -117,4 +117,12 @@ return [
             ],
         ],
     ],
+
+    'answer_inline_query' => [
+        /**
+         * Telegram cache time in seconds for answer inline query
+         * @see https://core.telegram.org/bots/api#answerinlinequery
+         */
+        'cache_time' => (int) env('TELEGRAPH_ANSWER_INLINE_QUERY_CACHE_TIME', 300),
+    ],
 ];

--- a/src/Concerns/AnswersInlineQueries.php
+++ b/src/Concerns/AnswersInlineQueries.php
@@ -23,6 +23,7 @@ trait AnswersInlineQueries
         $telegraph->endpoint = self::ENDPOINT_ANSWER_INLINE_QUERY;
         $telegraph->data = [
             'inline_query_id' => $inlineQueryID,
+            'cache_time' => config('telegraph.answer_inline_query.cache_time', 300),
             'results' => collect($results)->map(fn (InlineQueryResult $result) => $result->toArray())->toArray(),
         ];
 


### PR DESCRIPTION
[answerInlineQuery has](https://core.telegram.org/bots/api#answerinlinequery) `cache_time` parameter  which need to change cache between next request from tg to server. This is helpul parameter when you trying to use inline commands with changable data.