### PR TITLE
Automatic dependencies resolution for callback action method

### DIFF
--- a/docs/content/en/webhooks/callback-data.md
+++ b/docs/content/en/webhooks/callback-data.md
@@ -18,12 +18,12 @@ and will be handled by a public `action_name` method inside a custom [webhook ha
 *Telegraph* implements some useful methods to interact with the received callback query:
 
 
-Data can be retrieved from the payload using `->get()` method:
+Data can be retrieved from the payload by arguments of the function or using `->get()` method:
 
 ```php
 class CustomWebhookHandler extends WebhookHandler
 {
-    public function dismiss(){
+    public function dismiss(string $key2){ //bar
         //...
         
         $key1 = $this->data->get('key1'); //foo

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -19,6 +19,7 @@ use DefStudio\Telegraph\Models\TelegraphBot;
 use DefStudio\Telegraph\Models\TelegraphChat;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
@@ -64,7 +65,7 @@ abstract class WebhookHandler
             return;
         }
 
-        $this->$action();
+        App::call([$this, $action], $this->data->toArray());
     }
 
     private function handleCommand(Stringable $text): void

--- a/tests/Support/TestWebhookHandler.php
+++ b/tests/Support/TestWebhookHandler.php
@@ -63,6 +63,11 @@ class TestWebhookHandler extends WebhookHandler
         $this->chat->html("Hello!!")->send();
     }
 
+    public function param_injection(string $foo = 'not set'): void
+    {
+        $this->chat->html("Foo is [$foo]")->send();
+    }
+
     public function reply_to_command(): void
     {
         $this->reply('foo');

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -63,6 +63,22 @@ it('can handle a registered action', function () {
     expect(TestWebhookHandler::$calls_count)->toBe(1);
 });
 
+it('can handle a registered action with parameters', function () {
+    Config::set('telegraph.security.allow_callback_queries_from_unknown_chats', true);
+    Config::set('telegraph.security.allow_messages_from_unknown_chats', true);
+
+    $bot = make_bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_request('param_injection'), $bot);
+
+    Facade::assertSent("Foo is [not set]");
+
+    app(TestWebhookHandler::class)->handle(webhook_request('param_injection;foo:bar'), $bot);
+
+    Facade::assertSent("Foo is [bar]");
+});
+
 it('rejects unregistered actions', function () {
     Config::set('telegraph.security.allow_callback_queries_from_unknown_chats', true);
     Config::set('telegraph.security.allow_messages_from_unknown_chats', true);


### PR DESCRIPTION
Use Service Container [method invocation and injection](https://laravel.com/docs/10.x/container#method-invocation-and-injection).

Example:

```php
Keyboard::make()->buttons([
    Button::make('Generate')->action('generate')->param('id', '42'),
]);
```

WebhookHandler
```php
public function generate(UserRepository $repository, string $id): void
{
    $user = $repository->find($id); // $id = '42'
    // ...
}
```