### PR TITLE
Fix telegraph fake attached files not clearing between fake requests (ISSUE-432)

### DIFF
--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -103,6 +103,15 @@ class Telegraph extends Facade
         return $fake;
     }
 
+    public static function getFacadeRoot()
+    {
+        $instance = parent::getFacadeRoot();
+        if ($instance instanceof TelegraphFake) {
+            $instance->prepareForNewRequest();
+        }
+        return $instance;
+    }
+
     protected static function getFacadeAccessor(): string
     {
         return 'telegraph';

--- a/src/Support/Testing/Fakes/TelegraphFake.php
+++ b/src/Support/Testing/Fakes/TelegraphFake.php
@@ -15,6 +15,7 @@ use DefStudio\Telegraph\ScopedPayloads\TelegraphPollPayload;
 use DefStudio\Telegraph\ScopedPayloads\TelegraphQuizPayload;
 use DefStudio\Telegraph\Telegraph;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert;
 
 class TelegraphFake extends Telegraph
@@ -28,6 +29,10 @@ class TelegraphFake extends Telegraph
     {
         parent::__construct();
         $this->replies = $replies;
+    }
+
+    public function prepareForNewRequest(): void {
+        $this->files = new Collection();
     }
 
     public function editMedia(int $messageId): TelegraphEditMediaFake

--- a/tests/Regression/Issue-432-ClearTelegraphFakeFilesForNewRequestTest.php
+++ b/tests/Regression/Issue-432-ClearTelegraphFakeFilesForNewRequestTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use DefStudio\Telegraph\Facades\Telegraph as TelegraphFacade;
+
+test('Clear Telegraph Fake attached files for every new request', function() {
+    TelegraphFacade::fake();
+    $chat = make_chat();
+    $chat->photo(Storage::path('photo.jpg'))->message('test');
+    $telegraphB = $chat->message('123');
+    $filesB = $telegraphB->toArray()['files'];
+
+    expect($filesB)->toBeEmpty();
+});

--- a/tests/Unit/Storage/FileStoreDriverTest.php
+++ b/tests/Unit/Storage/FileStoreDriverTest.php
@@ -3,6 +3,7 @@
 use DefStudio\Telegraph\Concerns\HasStorage;
 use DefStudio\Telegraph\Contracts\Storable;
 use DefStudio\Telegraph\Models\TelegraphChat;
+use DefStudio\Telegraph\Tests\Unit\Storage\TestStorable;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
@@ -10,14 +11,7 @@ beforeEach(function () {
 });
 
 it('can store and retrieve data', function (string $key, mixed $value) {
-    $class = new class () implements Storable {
-        use HasStorage;
-
-        public function storageKey(): string
-        {
-            return 'foo';
-        }
-    };
+    $class = new TestStorable();
 
     $class->storage('file')->set($key, $value);
 
@@ -43,14 +37,7 @@ it('can store and retrieve data', function (string $key, mixed $value) {
 ]);
 
 it('can store and retrieve a model', function () {
-    $class = new class () implements Storable {
-        use HasStorage;
-
-        public function storageKey(): string
-        {
-            return 'foo';
-        }
-    };
+    $class = new TestStorable();
 
     $model = TelegraphChat::factory()->create();
 
@@ -75,14 +62,7 @@ it('can store and retrieve a model', function () {
 });
 
 it('can store and retrieve a nested model', function () {
-    $class = new class () implements Storable {
-        use HasStorage;
-
-        public function storageKey(): string
-        {
-            return 'foo';
-        }
-    };
+    $class = new TestStorable();
 
     $models = TelegraphChat::factory()->count(4)->create();
 

--- a/tests/Unit/Storage/TestStorable.php
+++ b/tests/Unit/Storage/TestStorable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DefStudio\Telegraph\Tests\Unit\Storage;
+
+use DefStudio\Telegraph\Concerns\HasStorage;
+use DefStudio\Telegraph\Contracts\Storable;
+
+class TestStorable implements Storable {
+    use HasStorage;
+
+    public function storageKey(): string
+    {
+        return 'foo';
+    }
+}


### PR DESCRIPTION
Issue https://github.com/defstudio/telegraph/issues/432

And refactor FileStoreDriverTest to pass tests in Windows
![005745](https://github.com/defstudio/telegraph/assets/84812777/be70cbb1-0eb7-4551-8dd1-286ff2ee20de)
