### PR TITLE
Update composer.json to use Larastan Org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "friendsofphp/php-cs-fixer": "^v3.13.0",
         "guzzlehttp/guzzle": "^7.5.0",
         "nunomaduro/collision": "^v5.11.0 | ^v6.3.1",
-        "nunomaduro/larastan": "^1.0.4 | ^2.4.0",
+        "larastan/larastan": "^1.0.4 | ^2.4.0",
         "orchestra/testbench": "^v6.25.1 | ^v7.13.0 | ^8.0",
         "pestphp/pest": "^v1.22.2",
         "pestphp/pest-plugin-laravel": "^v1.3.0",


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization. 