### PR TITLE
[feat] allows to change a bot's default menu button

### DIFF
--- a/docs/content/12.features/8.telegram-api-calls.md
+++ b/docs/content/12.features/8.telegram-api-calls.md
@@ -346,13 +346,15 @@ title: my telegram group
 
 ## setChatMenuButton
 
-Set menu button. For detailed info, see [docs](https://core.telegram.org/bots/api#menubutton)
+Set menu button. For detailed info, see docs [here](https://core.telegram.org/bots/api#menubutton) and [here](https://core.telegram.org/bots/api#setchatmenubutton)
 
 ```php
 Telegraph::setChatMenuButton()->default()->send(); //restore default 
 Telegraph::setChatMenuButton()->commands()->send(); //show bot commands in menu button 
 Telegraph::setChatMenuButton()->webApp("Web App", "https://my-web.app")->send(); //show start web app button 
 ```
+
+**note:** if no chat is active when calling this, the default bot's menu button will be changed.
 
 ## chatMenuButton
 

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -260,7 +260,11 @@ trait HasBotsAndChats
     {
         $telegraph = clone $this;
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_MENU_BUTTON;
-        $telegraph->data['chat_id'] = $this->getChatId();
+
+        if ($this->getChatIfAvailable() !== null) {
+            $telegraph->data['chat_id'] = $this->getChatId();
+        }
+
 
         return SetChatMenuButtonPayload::makeFrom($telegraph);
     }

--- a/tests/Unit/Concerns/HasBotsAndChatsTest.php
+++ b/tests/Unit/Concerns/HasBotsAndChatsTest.php
@@ -416,6 +416,13 @@ it('can set commands chat menu button', function () {
     })->toMatchTelegramSnapshot();
 });
 
+it('can set commands bot menu button', function () {
+    expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
+        return $telegraph
+            ->setChatMenuButton()->commands();
+    })->toMatchTelegramSnapshot();
+});
+
 it('can set web app chat menu button', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {
         return $telegraph->chat(make_chat())

--- a/tests/__snapshots__/HasBotsAndChatsTest__it_can_set_commands_bot_menu_button__1.yml
+++ b/tests/__snapshots__/HasBotsAndChatsTest__it_can_set_commands_bot_menu_button__1.yml
@@ -1,0 +1,5 @@
+url: 'https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/setChatMenuButton'
+payload:
+    chat_id: '-123456789'
+    menu_button: { type: commands }
+files: {  }


### PR DESCRIPTION
fix #479 allowing to call setChatMenuButton() without an active chat