### PR TITLE
#549 add properties assignments in KeyboardButtonProxy and ReplyKeyboardButtonProxy constructors

### DIFF
--- a/src/Proxies/KeyboardButtonProxy.php
+++ b/src/Proxies/KeyboardButtonProxy.php
@@ -22,6 +22,7 @@ class KeyboardButtonProxy extends Keyboard
     public function __construct(Keyboard $proxyed, Button $button)
     {
         parent::__construct();
+        $this->rtl = $proxyed->rtl;
         $this->button = $button;
         $this->buttons = $proxyed->buttons;
     }

--- a/src/Proxies/ReplyKeyboardButtonProxy.php
+++ b/src/Proxies/ReplyKeyboardButtonProxy.php
@@ -24,6 +24,11 @@ class ReplyKeyboardButtonProxy extends ReplyKeyboard
     public function __construct(ReplyKeyboard $proxyed, ReplyButton $button)
     {
         parent::__construct();
+        $this->rtl = $proxyed->rtl;
+        $this->resize = $proxyed->resize;
+        $this->oneTime = $proxyed->oneTime;
+        $this->selective = $proxyed->selective;
+        $this->inputPlaceholder = $proxyed->inputPlaceholder;
         $this->button = $button;
         $this->buttons = $proxyed->buttons;
     }


### PR DESCRIPTION
With these changes sequential keyboard property assignment will work properly:

```php
$telegraph->markdown('Registration needed')->replyKeyboard(
    ReplyKeyboard::make()
        ->button('Send contact')->requestContact()
        ->button('Cancel')
        ->resize()
        ->oneTime()
        ->inputPlaceholder("Waiting for input")
)->send();
```