### PR TITLE
Add "down" for rollback in "create_telegraph_chats_table"

### DIFF
--- a/database/migrations/create_telegraph_chats_table.php
+++ b/database/migrations/create_telegraph_chats_table.php
@@ -18,4 +18,9 @@ return new class () extends Migration {
             $table->unique(['chat_id', 'telegraph_bot_id']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('telegraph_chats');
+    }
 };


### PR DESCRIPTION
increases convenience and adds the ability to make migrate:rollback