### PR TITLE
Add "down" for rollback in "create_telegraph_bots_table"

### DIFF
--- a/database/migrations/create_telegraph_bots_table.php
+++ b/database/migrations/create_telegraph_bots_table.php
@@ -15,4 +15,9 @@ return new class () extends Migration {
             $table->timestamps();
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('telegraph_bots');
+    }
 };


### PR DESCRIPTION
enhances convenience and adds the ability to make migrate:rollback