### PR TITLE
Fix config breaking change in minor release

### DIFF
--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -20,7 +20,7 @@ class WebhookController
         $bot = $botModel::fromToken($token);
 
         /** @var class-string $handler */
-        $handler = config('telegraph.webhook.handler', config('telegraph.webhook_handler'));
+        $handler = config('telegraph.webhook_handler', config('telegraph.webhook.handler'));
 
         /** @var WebhookHandler $handler */
         $handler = app($handler);


### PR DESCRIPTION
This PR fixes a breaking change when people upgrade to `1.42`.

The latest release changes the config key for the webhook handler from `telegraph.webhook_handler` to `telegraph.webhook.handler`. However, it doesn't handle backward compatibility correctly.

The following line in `WebhookController` attempts to use the new config value while falling back to the old one.
https://github.com/defstudio/telegraph/blob/d5176bcebb41982a2a266eb54ff92298080f76c8/src/Controllers/WebhookController.php#L23

Since the package internal config file is merged with the app's published config file, the `telegraph.webhook.handler` key will always be available and the fallback is thus redundant.

This should however be the other way around, as we ideally want to first check with the old key and fallback to the new one since people will still have the old config published.

It should look like this;

```
$handler = config('telegraph.webhook_handler', config('telegraph.webhook.handler'));
```