### PR TITLE
teletraph chat retrieve optimization

### DIFF
--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -36,14 +36,6 @@ trait HasBotsAndChats
 
         $telegraph->bot = $bot;
 
-        if (empty($telegraph->chat) && $bot instanceof TelegraphBot) {
-            if ($bot->relationLoaded('chats')) {
-                $telegraph->chat = rescue(fn () => $bot->chats->sole(), report: false);
-            } elseif ($bot->chats()->count() === 1) {
-                $telegraph->chat = $bot->chats()->first();
-            }
-        }
-
         return $telegraph;
     }
 
@@ -98,21 +90,21 @@ trait HasBotsAndChats
             $bot = $telegraph->getBotIfAvailable();
 
             if ($bot instanceof TelegraphBot) {
-                /** @var TelegraphChat|string $chat */
-                $chat = rescue(fn () => $bot->chats()->sole(), config('telegraph.chat_id'), false);
-
-                $telegraph->chat = $chat;
+                if ($bot->relationLoaded('chats')) {
+                    $telegraph->chat = rescue(fn () => $bot->chats->sole(), report: false);
+                } elseif ($bot->chats()->count() === 1) {
+                    $telegraph->chat = $bot->chats()->first();
+                }
             }
         }
 
         if (empty($telegraph->chat)) {
-            /** @var TelegraphChat $chat */
-            $chat = rescue(fn () => TelegraphChat::query()->sole(), null, false);
-
-            $telegraph->chat = $chat;
+            if (TelegraphChat::count() === 1) {
+                $telegraph->chat = TelegraphChat::first();
+            }
         }
 
-        return $telegraph->chat;
+        return $telegraph->chat ?? null;
     }
 
     protected function getChat(): TelegraphChat|string

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -90,18 +90,12 @@ trait HasBotsAndChats
             $bot = $telegraph->getBotIfAvailable();
 
             if ($bot instanceof TelegraphBot) {
-                if ($bot->relationLoaded('chats')) {
-                    $telegraph->chat = rescue(fn () => $bot->chats->sole(), report: false);
-                } elseif ($bot->chats()->count() === 1) {
-                    $telegraph->chat = $bot->chats()->first();
-                }
+                $telegraph->chat = rescue(fn () => $bot->chats()->sole(), report: false);
             }
         }
 
         if (empty($telegraph->chat)) {
-            if (TelegraphChat::count() === 1) {
-                $telegraph->chat = TelegraphChat::first();
-            }
+            $telegraph->chat = rescue(fn () => TelegraphChat::query()->sole(), report: false);
         }
 
         return $telegraph->chat ?? null;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -54,7 +54,10 @@ function bot(string $token = '3f3814e1-5836-3d77-904e-60f64b15df36', string $cha
 function make_bot(): TelegraphBot
 {
     $bot = TelegraphBot::factory(['token' => '3f3814e1-5836-3d77-904e-60f64b15df36'])->make();
-    $bot->setRelation('chats', Collection::make([TelegraphChat::factory(['chat_id' => '-123456789'])->make()]));
+
+    $chat = TelegraphChat::factory(['chat_id' => '-123456789'])->make();
+
+    $bot->setRelation('chats', Collection::make([$chat]));
 
     return $bot;
 }

--- a/tests/Unit/Client/TelegraphResponseTest.php
+++ b/tests/Unit/Client/TelegraphResponseTest.php
@@ -23,7 +23,7 @@ it('wraps original response', function () use ($fake_response_data) {
     ]);
     $bot = make_bot();
 
-    $response = Telegraph::bot($bot)->message('foo')->send();
+    $response = Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     expect($response->body())->toMatchSnapshot();
 
@@ -34,7 +34,7 @@ it('returns telegram request success', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    $response = Telegraph::bot($bot)->message('foo')->send();
+    $response = Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     expect($response->telegraphOk())->toBeTrue();
     expect($response->telegraphError())->toBeFalse();
@@ -46,7 +46,7 @@ it('returns telegram request failure', function () {
     ]);
     $bot = make_bot();
 
-    $response = Telegraph::bot($bot)->message('foo')->send();
+    $response = Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     expect($response->telegraphOk())->toBeFalse();
     expect($response->telegraphError())->toBeTrue();
@@ -58,7 +58,7 @@ it('returns telegram posted message id', function () use ($fake_response_data) {
     ]);
     $bot = make_bot();
 
-    $response = Telegraph::bot($bot)->message('foo')->send();
+    $response = Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     expect($response->telegraphMessageId())->toBe(41302);
 });

--- a/tests/Unit/Support/Testing/TelegraphFakeTest.php
+++ b/tests/Unit/Support/Testing/TelegraphFakeTest.php
@@ -12,7 +12,7 @@ it('can return a custom response', function () {
 
     $bot = make_bot();
 
-    $response = Telegraph::bot($bot)->message('foo')->send();
+    $response = Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     expect($response->json('result'))->toBe('oooook');
 });
@@ -21,7 +21,7 @@ it('asserts a message is sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->message('foo')->send();
+    Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     Telegraph::assertSent('foo');
 });
@@ -30,7 +30,7 @@ it('fails if the given message is not sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->message('foo')->send();
+    Telegraph::chat($bot->chats->first())->message('foo')->send();
 
     Telegraph::assertSent('bar');
 })->throws(ExpectationFailedException::class, 'Failed to assert that a request was sent to [sendMessage] endpoint with the given data (sent 1 requests so far)');
@@ -40,7 +40,7 @@ it('asserts a partial message is sent', function () {
 
     Telegraph::fake();
 
-    Telegraph::bot($bot)->message('foo bar baz')->send();
+    Telegraph::chat($bot->chats->first())->message('foo bar baz')->send();
 
     Telegraph::assertSent('baz', exact: false);
 });
@@ -50,7 +50,7 @@ it('fails if exact message sent check is found partially', function () {
     $bot = make_bot();
 
 
-    Telegraph::bot($bot)->message('foo bar baz')->send();
+    Telegraph::chat($bot->chats->first())->message('foo bar baz')->send();
 
     Telegraph::assertSent('baz');
 })->throws(ExpectationFailedException::class, 'Failed to assert that a request was sent to [sendMessage] endpoint with the given data (sent 1 requests so far)');
@@ -65,7 +65,7 @@ it('fails if an unexpected message is sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->message('foo bar baz')->send();
+    Telegraph::chat($bot->chats->first())->message('foo bar baz')->send();
 
     Telegraph::assertNothingSent();
 })->throws(ExpectationFailedException::class, 'Failed to assert that no request were sent (sent 1 requests so far)');
@@ -74,8 +74,8 @@ it('asserts data was sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->message('foo bar baz')->send();
-    Telegraph::bot($bot)->deleteKeyboard(42)->send();
+    Telegraph::chat($bot->chats->first())->message('foo bar baz')->send();
+    Telegraph::chat($bot->chats->first())->deleteKeyboard(42)->send();
 
     Telegraph::assertSentData(DefStudio\Telegraph\Telegraph::ENDPOINT_MESSAGE, ['text' => 'foo bar baz']);
     Telegraph::assertSentData(DefStudio\Telegraph\Telegraph::ENDPOINT_REPLACE_KEYBOARD, [
@@ -95,7 +95,7 @@ it('fails if the expected data differs from the sent one', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->message('foo bar baz')->send();
+    Telegraph::chat($bot->chats->first())->message('foo bar baz')->send();
 
     Telegraph::assertSentData(DefStudio\Telegraph\Telegraph::ENDPOINT_MESSAGE, ['text' => 'foo bar']);
 })->throws(ExpectationFailedException::class, 'Failed to assert that a request was sent to [sendMessage] endpoint with the given data (sent 1 requests so far)');
@@ -106,7 +106,7 @@ it('asserts a webhook has been registered', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->registerWebhook()->send();
+    Telegraph::chat($bot->chats->first())->registerWebhook()->send();
 
     Telegraph::assertRegisteredWebhook();
 });
@@ -115,7 +115,7 @@ it('asserts a webhook has been unregistered', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->unregisterWebhook()->send();
+    Telegraph::chat($bot->chats->first())->unregisterWebhook()->send();
 
     Telegraph::assertUnregisteredWebhook();
 });
@@ -130,7 +130,7 @@ it('asserts webhook debug info have been requested', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->getWebhookDebugInfo()->send();
+    Telegraph::chat($bot->chats->first())->getWebhookDebugInfo()->send();
 
     Telegraph::assertRequestedWebhookDebugInfo();
 });
@@ -145,7 +145,7 @@ it('asserts a webhook reply has been sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->replyWebhook(44, 'hello')->send();
+    Telegraph::chat($bot->chats->first())->replyWebhook(44, 'hello')->send();
 
     Telegraph::assertRepliedWebhook('hello');
 });
@@ -154,7 +154,7 @@ it('asserts a webhook reply has been sent as alert', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->replyWebhook(44, 'hello', true)->send();
+    Telegraph::chat($bot->chats->first())->replyWebhook(44, 'hello', true)->send();
 
     Telegraph::assertRepliedWebhookIsAlert();
 });
@@ -163,7 +163,7 @@ it('fails if the wrong webhook reply has been sent', function () {
     Telegraph::fake();
     $bot = make_bot();
 
-    Telegraph::bot($bot)->replyWebhook(44, 'hello')->send();
+    Telegraph::chat($bot->chats->first())->replyWebhook(44, 'hello')->send();
 
     Telegraph::assertRepliedWebhook('foo');
 })->throws(ExpectationFailedException::class, 'Failed to assert that a request was sent to [answerCallbackQuery] endpoint with the given data (sent 1 requests so far)');


### PR DESCRIPTION
defers chat retrieval until it is actually used

fix #568 