### PR TITLE
[fix] message not set up before retrieving Chat

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -277,7 +277,7 @@ abstract class WebhookHandler
         if (isset($this->message)){
             $telegramChat = $this->message?->chat() ?? $this->callbackQuery?->message()?->chat();
         } else {
-            $telegramChat = $this->callbackQuery?->message()?->chat();;
+            $telegramChat = $this->callbackQuery?->message()?->chat();
         }
 
         assert($telegramChat !== null);

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -273,7 +273,12 @@ abstract class WebhookHandler
 
     protected function setupChat(): void
     {
-        $telegramChat = $this->message?->chat() ?? $this->callbackQuery?->message()?->chat();
+
+        if (isset($this->message)){
+            $telegramChat = $this->message?->chat() ?? $this->callbackQuery?->message()?->chat();
+        } else {
+            $telegramChat = $this->callbackQuery?->message()?->chat();;
+        }
 
         assert($telegramChat !== null);
 

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -275,7 +275,7 @@ abstract class WebhookHandler
     {
 
         if (isset($this->message)){
-            $telegramChat = $this->message?->chat() ?? $this->callbackQuery?->message()?->chat();
+            $telegramChat = $this->message->chat();
         } else {
             $telegramChat = $this->callbackQuery?->message()?->chat();
         }


### PR DESCRIPTION
I had an issue with getting an error when returning an action from a keyboard button.

I tracked it down to this line

https://github.com/defstudio/telegraph/blob/231947e26930e258e79e5ce2e79c2163eac2c81d/src/Handlers/WebhookHandler.php#L276-L277

It seems there is an issue here if `$this->message` isnt available.

I simply pulled out the `message` check into an if block to make it clearer and also to avoid the error.

With this the code runs fine.

I am unsure how to run your tests, perhaps you might let me know or run them and see if there is an extra issue.

Thanks
 