### PR TITLE
Added ability to set timeout on file transfers

### DIFF
--- a/config/telegraph.php
+++ b/config/telegraph.php
@@ -162,4 +162,9 @@ return [
             'max_size_mb' => 50,
         ],
     ],
+    /**
+     * Timeout in seconds when sending and receiving files from telegram
+     */
+    'file_transfer_timeout' => 30,
+
 ];

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -41,7 +41,7 @@ trait InteractsWithTelegram
         );
 
         /** @phpstan-ignore-next-line  */
-        return $request->post($this->getApiUrl(), $this->prepareData());
+        return $request->timeout(config('telegraph.file_transfer_timeout', 30))->post($this->getApiUrl(), $this->prepareData());
     }
 
     /**

--- a/src/Jobs/SendRequestToTelegramJob.php
+++ b/src/Jobs/SendRequestToTelegramJob.php
@@ -41,7 +41,7 @@ class SendRequestToTelegramJob implements ShouldQueue
             },
             $request
         );
-
-        $request->post($this->url, $this->data);
+        /** @phpstan-ignore-next-line */
+        $request->timeout(config('telegraph.file_transfer_timeout', 30))->post($this->url, $this->data);
     }
 }


### PR DESCRIPTION
I added the ability to add a timeout setting in the config file so that when transferring files that are big we do not get an error, I already opened a bug at #591 