### PR TITLE
Fix UserDTO

### DIFF
--- a/src/DTO/User.php
+++ b/src/DTO/User.php
@@ -25,7 +25,7 @@ class User implements Arrayable, Storable
     }
 
     /**
-     * @param array{id:int, is_bot?:bool, first_name:string, last_name?:string, username?:string, language_code?:string, is_premium?:bool} $data
+     * @param array{id:int, is_bot?:bool, first_name?:string, last_name?:string, username?:string, language_code?:string, is_premium?:bool} $data
      */
     public static function fromArray(array $data): User
     {
@@ -34,7 +34,7 @@ class User implements Arrayable, Storable
         $user->id = $data['id'];
         $user->isBot = $data['is_bot'] ?? false;
 
-        $user->firstName = $data['first_name'];
+        $user->firstName = $data['first_name'] ?? '';
         $user->lastName = $data['last_name'] ?? '';
         $user->username = $data['username'] ?? '';
         $user->languageCode = $data['language_code'] ?? '';

--- a/tests/Regression/Issue-619-NullFirstNameTest.php
+++ b/tests/Regression/Issue-619-NullFirstNameTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use DefStudio\Telegraph\DTO\User;
+use Illuminate\Support\Str;
+
+test('null first_name for user dto', function () {
+    $dto = User::fromArray([
+        'id' => 1,
+        'is_bot' => false,
+        'first_name' => null,
+    ]);
+
+    $array = $dto->toArray();
+
+    $reflection = new ReflectionClass($dto);
+    foreach ($reflection->getProperties() as $property) {
+        expect($array)->toHaveKey(Str::of($property->name)->snake());
+    }
+});


### PR DESCRIPTION
I got an error today that some of the **first_name** in the **left_chat_member** object is null
I think when a deleted account removed from group, the first name is null

![image](https://github.com/user-attachments/assets/d696951a-2102-432d-bbe9-ef15842699fa)

I had to return null safe to first_name to avoid generating an error