### PR TITLE
add $dropPendingUpdates param to registerWebhook method

### DIFF
--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -29,13 +29,14 @@ trait InteractsWithWebhooks
         return $customWebhookUrl . route('telegraph.webhook', $this->getBot(), false);
     }
 
-    public function registerWebhook(): Telegraph
+    public function registerWebhook(bool $dropPendingUpdates = false): Telegraph
     {
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_WEBHOOK;
         $telegraph->data = [
             'url' => $this->getWebhookUrl(),
+            'drop_pending_updates' => $dropPendingUpdates,
         ];
 
         return $telegraph;


### PR DESCRIPTION
The $dropPendingUpdates option drops updates that Telegram tries to send to the bot.
This helps in cases where the bot caught an unhandled error and crashed. Next, I will correct the code, register the webhook again, thereby removing many updates that will sprinkle the bot within a minute.