### PR TITLE
Make protected methods

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -51,7 +51,7 @@ abstract class WebhookHandler
         $this->originalKeyboard = Keyboard::make();
     }
 
-    private function handleCallbackQuery(): void
+    protected function handleCallbackQuery(): void
     {
         $this->extractCallbackQueryData();
 
@@ -73,7 +73,7 @@ abstract class WebhookHandler
         App::call([$this, $action], $this->data->toArray());
     }
 
-    private function handleCommand(Stringable $text): void
+    protected function handleCommand(Stringable $text): void
     {
         $command = (string) $text->after('/')->before(' ')->before('@');
         $parameter = (string) $text->after('@')->after(' ');
@@ -100,7 +100,7 @@ abstract class WebhookHandler
         }
     }
 
-    private function handleMessage(): void
+    protected function handleMessage(): void
     {
         $this->extractMessageData();
 


### PR DESCRIPTION
The main problem with private methods is that they cannot be overridden.

By default, the `handleCommand` method looks for commands starting with `/`, but what if they have different names? For example, `/start`, `!start`, `:start`?

Of course, it is possible to add this functionality to this package, but it would be better done in another PR.

Now, why `protected`? Because I can't override private methods, I have to also override other methods that call them. So on the output I get a copypaste of the `WebhookHandler` class with minor changes instead of doing it this way:

```php
abstract class Webhook extends WebhookHandler
{
    protected function handleCommand(Stringable $text): void
    {
        $command   = (string) $text->after('/')->after('!')->before(' ')->before('@');
        $parameter = (string) $text->after('@')->after(' ');

        if (! $this->canHandle($command)) {
            $this->handleUnknownCommand($text);

            return;
        }

        $this->$command($parameter);
    }
}
```

The same is true for other methods.

<details><summary>My webhook class in the app without these changes looks like this</summary>

```php
<?php

declare(strict_types=1);

namespace App\Http\Webhooks;

use DefStudio\Telegraph\DTO\CallbackQuery;
use DefStudio\Telegraph\DTO\Chat;
use DefStudio\Telegraph\DTO\InlineQuery;
use DefStudio\Telegraph\DTO\Message;
use DefStudio\Telegraph\Exceptions\TelegramWebhookException;
use DefStudio\Telegraph\Handlers\WebhookHandler;
use DefStudio\Telegraph\Models\TelegraphBot;
use Illuminate\Http\Request;
use Illuminate\Support\Collection;
use Illuminate\Support\Facades\App;
use Illuminate\Support\Facades\Log;
use Illuminate\Support\Str;
use Illuminate\Support\Stringable;
use Throwable;

abstract class Webhook extends WebhookHandler
{
    public function handle(Request $request, TelegraphBot $bot): void
    {
        try {
            $this->bot = $bot;

            $this->request = $request;

            if ($this->request->has('message')) {
                /* @phpstan-ignore-next-line */
                $this->message = Message::fromArray($this->request->input('message'));
                $this->handleMessage();

                return;
            }

            if ($this->request->has('edited_message')) {
                /* @phpstan-ignore-next-line */
                $this->message = Message::fromArray($this->request->input('edited_message'));
                $this->handleMessage();

                return;
            }

            if ($this->request->has('channel_post')) {
                /* @phpstan-ignore-next-line */
                $this->message = Message::fromArray($this->request->input('channel_post'));
                $this->handleMessage();

                return;
            }

            if ($this->request->has('callback_query')) {
                /* @phpstan-ignore-next-line */
                $this->callbackQuery = CallbackQuery::fromArray($this->request->input('callback_query'));
                $this->handleCallbackQuery();
            }

            if ($this->request->has('inline_query')) {
                /* @phpstan-ignore-next-line */
                $this->handleInlineQuery(InlineQuery::fromArray($this->request->input('inline_query')));
            }
        }
        catch (Throwable $throwable) {
            $this->onFailure($throwable);
        }
    }

    protected function handleUnknownCommand(Stringable $text): void
    {
        if ($this->message?->chat()?->type() === Chat::TYPE_PRIVATE) {
            if (
                config(
                    'telegraph.report_unknown_webhook_commands',
                    config('telegraph.webhook.report_unknown_commands', true)
                )
            ) {
                report(TelegramWebhookException::invalidCommand($this->parseCommand($text)[0]));
            }

            $this->chat->html(__('telegraph::errors.invalid_command'))->send();
        }
    }

    protected function handleCallbackQuery(): void
    {
        $this->extractCallbackQueryData();

        if (config('telegraph.debug_mode', config('telegraph.webhook.debug'))) {
            Log::debug('Telegraph webhook callback', $this->data->toArray());
        }

        /** @var string $action */
        $action = $this->callbackQuery?->data()->get('action') ?? '';

        if (! $this->canHandle($action)) {
            report(TelegramWebhookException::invalidAction($action));
            $this->reply(__('telegraph::errors.invalid_action'));

            return;
        }

        /** @phpstan-ignore-next-line */
        App::call([$this, $action], $this->data->toArray());
    }

    protected function handleCommand(Stringable $text): void
    {
        [$command, $parameter] = $this->parseCommand($text);

        if (! $this->canHandle($command)) {
            $this->handleUnknownCommand($text);

            return;
        }

        $this->$command($parameter);
    }

    protected function handleMessage(): void
    {
        $this->extractMessageData();

        if (config('telegraph.debug_mode', config('telegraph.webhook.debug'))) {
            Log::debug('Telegraph webhook message', $this->data->toArray());
        }

        $text = Str::of($this->message?->text() ?? '');

        if ($text->startsWith($this->commandStartWith())) {
            $this->handleCommand($text);

            return;
        }

        if ($this->message?->newChatMembers()->isNotEmpty()) {
            foreach ($this->message->newChatMembers() as $member) {
                $this->handleChatMemberJoined($member);
            }

            return;
        }

        if ($this->message?->leftChatMember() !== null) {
            $this->handleChatMemberLeft($this->message->leftChatMember());

            return;
        }

        $this->handleChatMessage($text);
    }

    protected function parseCommand(Stringable $text): array
    {
        $command   = (string) $text->before('@')->before(' ');
        $parameter = (string) $text->after('@')->after(' ');

        $this->commandStartWith()->each(function (string $value) use (&$command) {
            $command = Str::after($command, $value);
        });

        return [$command, $parameter];
    }

    protected function commandStartWith(): Collection
    {
        return collect(config('telegraph.commands.start_with', []))
            ->push('/')
            ->map(fn (mixed $value) => Str::replace(' ', '', $value))
            ->unique();
    }
}
```

</details> 