### PR TITLE
Added the ability to specify different prefixes for command definitions

### DIFF
--- a/config/telegraph.php
+++ b/config/telegraph.php
@@ -185,4 +185,16 @@ return [
             'max_size_mb' => 50,
         ],
     ],
+
+    /*
+     * Sets preferences for commands
+     */
+    'commands' => [
+        /*
+         * Defines a list of characters that are the identifier of a command sent to the chat.
+         *
+         * Default is `/`
+         */
+        'start_with' => ['/'],
+    ],
 ];

--- a/src/Concerns/FakesRequests.php
+++ b/src/Concerns/FakesRequests.php
@@ -293,7 +293,7 @@ trait FakesRequests
                 foreach ($data ?? [] as $key => $value) {
                     /** @var array<string, string> $data */
                     $messageData = $message['data'];
-                    if (! Arr::has($messageData, $key)) {
+                    if (!Arr::has($messageData, $key)) {
                         return false;
                     }
 
@@ -301,9 +301,8 @@ trait FakesRequests
                         if ($value != $messageData[$key]) {
                             return false;
                         }
-                    }
-                    else {
-                        if (! Str::of($messageData[$key])->contains($value)) {
+                    } else {
+                        if (!Str::of($messageData[$key])->contains($value)) {
                             return false;
                         }
                     }

--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -85,6 +85,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void  assertSentData(string $endpoint, array $data = null, bool $exact = true)
  * @method static void  assertSentFiles(string $endpoint, array $files = null)
  * @method static void  assertSent(string $message, bool $exact = true)
+ * @method static void  assertNotSent(string $message, bool $exact = true)
  * @method static void  assertNothingSent()
  * @method static void  assertRegisteredWebhook(array $data = null, bool $exact = true)
  * @method static void  assertUnregisteredWebhook(array $data = null, bool $exact = true)

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -337,7 +337,7 @@ abstract class WebhookHandler
     {
         return collect(config('telegraph.commands.start_with', []))
             ->push('/')
-            ->map(fn (mixed $value) => trim((string) $value))
+            ->map(fn (mixed $value) => Str::replace(' ', '', $value))
             ->unique();
     }
 }

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -323,7 +323,7 @@ abstract class WebhookHandler
 
     protected function parseCommand(Stringable $text): array
     {
-        $command   = (string) $text->before('@')->before(' ');
+        $command = (string) $text->before('@')->before(' ');
         $parameter = (string) $text->after('@')->after(' ');
 
         $this->commandStartWith()->each(function (string $value) use (&$command) {

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -75,8 +75,7 @@ abstract class WebhookHandler
 
     private function handleCommand(Stringable $text): void
     {
-        $command = (string) $text->after('/')->before(' ')->before('@');
-        $parameter = (string) $text->after('@')->after(' ');
+        [$command, $parameter] = $this->parseCommand($text);
 
         if (!$this->canHandle($command)) {
             $this->handleUnknownCommand($text);
@@ -90,10 +89,8 @@ abstract class WebhookHandler
     protected function handleUnknownCommand(Stringable $text): void
     {
         if ($this->message?->chat()?->type() === Chat::TYPE_PRIVATE) {
-            $command = (string) $text->after('/')->before(' ')->before('@');
-
             if (config('telegraph.report_unknown_webhook_commands', config('telegraph.webhook.report_unknown_commands', true))) {
-                report(TelegramWebhookException::invalidCommand($command));
+                report(TelegramWebhookException::invalidCommand($this->parseCommand($text)[0]));
             }
 
             $this->chat->html(__('telegraph::errors.invalid_command'))->send();
@@ -110,7 +107,7 @@ abstract class WebhookHandler
 
         $text = Str::of($this->message?->text() ?? '');
 
-        if ($text->startsWith('/')) {
+        if ($text->startsWith($this->commandStartWith())) {
             $this->handleCommand($text);
 
             return;
@@ -322,5 +319,25 @@ abstract class WebhookHandler
         report($throwable);
 
         rescue(fn () => $this->reply(__('telegraph::errors.webhook_error_occurred')), report: false);
+    }
+
+    protected function parseCommand(Stringable $text): array
+    {
+        $command   = (string) $text->before('@')->before(' ');
+        $parameter = (string) $text->after('@')->after(' ');
+
+        $this->commandStartWith()->each(function (string $value) use (&$command) {
+            $command = Str::after($command, $value);
+        });
+
+        return [$command, $parameter];
+    }
+
+    protected function commandStartWith(): Collection
+    {
+        return collect(config('telegraph.commands.start_with', []))
+            ->push('/')
+            ->map(fn (mixed $value) => trim((string) $value))
+            ->unique();
     }
 }

--- a/src/Support/Testing/Fakes/TelegraphFake.php
+++ b/src/Support/Testing/Fakes/TelegraphFake.php
@@ -130,6 +130,13 @@ class TelegraphFake extends Telegraph
         ], $exact);
     }
 
+    public function assertNotSent(string $message, bool $exact = true): void
+    {
+        $this->assertNotSentData(Telegraph::ENDPOINT_MESSAGE, [
+            'text' => $message,
+        ], $exact);
+    }
+
     public function assertNothingSent(): void
     {
         Assert::assertEmpty(self::$sentMessages, sprintf("Failed to assert that no request were sent (sent %d requests so far)", count(self::$sentMessages)));

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -212,6 +212,47 @@ it('can handle a command with parameters and bot reference', function () {
     Facade::assertSent("Hello!! your parameter is [foo bot]");
 });
 
+it('can handle a command with custom start char', function () {
+    Config::set('telegraph.commands.start_with', ['-', '=', '!', ' % ', 1]);
+
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_command('/hello@bot foo bot /'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('-hello@bot foo bot -'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('=hello@bot foo bot ='), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('!hello@bot foo bot !'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('%hello@bot foo bot %'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('1hello@bot foo bot 1'), $bot);
+
+    Facade::assertSent("Hello!! your parameter is [foo bot /]");
+    Facade::assertSent("Hello!! your parameter is [foo bot -]");
+    Facade::assertSent("Hello!! your parameter is [foo bot =]");
+    Facade::assertSent("Hello!! your parameter is [foo bot !]");
+    Facade::assertSent("Hello!! your parameter is [foo bot %]");
+    Facade::assertSent("Hello!! your parameter is [foo bot 1]");
+});
+
+it('cannot handle a command with custom start char', function () {
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_command('/hello@bot foo bot /'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('-hello@bot foo bot -'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('=hello@bot foo bot ='), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('!hello@bot foo bot !'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('%hello@bot foo bot %'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('1hello@bot foo bot 1'), $bot);
+
+    Facade::assertSent("Hello!! your parameter is [foo bot /]");
+
+    Facade::assertNotSent("Hello!! your parameter is [foo bot -]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot =]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot !]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot %]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot 1]");
+});
+
 it('can change the inline keyboard', function () {
     Config::set('telegraph.security.allow_callback_queries_from_unknown_chats', true);
     Config::set('telegraph.security.allow_messages_from_unknown_chats', true);

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -213,7 +213,7 @@ it('can handle a command with parameters and bot reference', function () {
 });
 
 it('can handle a command with custom start char', function () {
-    Config::set('telegraph.commands.start_with', ['-', '=', '!', ' % ', 1]);
+    Config::set('telegraph.commands.start_with', ['-', '=', '!', ' % ', 1, ' : : ']);
 
     $bot = bot();
     Facade::fake();
@@ -224,6 +224,7 @@ it('can handle a command with custom start char', function () {
     app(TestWebhookHandler::class)->handle(webhook_command('!hello@bot foo bot !'), $bot);
     app(TestWebhookHandler::class)->handle(webhook_command('%hello@bot foo bot %'), $bot);
     app(TestWebhookHandler::class)->handle(webhook_command('1hello@bot foo bot 1'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('::hello@bot foo bot : :'), $bot);
 
     Facade::assertSent("Hello!! your parameter is [foo bot /]");
     Facade::assertSent("Hello!! your parameter is [foo bot -]");
@@ -231,6 +232,7 @@ it('can handle a command with custom start char', function () {
     Facade::assertSent("Hello!! your parameter is [foo bot !]");
     Facade::assertSent("Hello!! your parameter is [foo bot %]");
     Facade::assertSent("Hello!! your parameter is [foo bot 1]");
+    Facade::assertSent("Hello!! your parameter is [foo bot : :]");
 });
 
 it('cannot handle a command with custom start char', function () {


### PR DESCRIPTION
This change will allow you to move away from the usual commands starting with the `/` symbol using any form the developer wishes.

For example:

```php
// config/telegraph.php
return [
    'commands' => [
        'start_with' => ['-', '!', ' % ', 1],
    ],
];
```
These are the commands:
```
/hello@bot foo bot
-hello@bot foo bot
!hello@bot foo bot
%hello@bot foo bot
1hello@bot foo bot
```
They're not commands:
```
\hello@bot foo bot
]hello@bot foo bot
[hello@bot foo bot
_hello@bot foo bot
```

The `/` character will be used by default in any case.