### PR TITLE
Added independent methods for saving a chat and forming its name

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -293,9 +293,7 @@ abstract class WebhookHandler
             }
 
             if (config('telegraph.security.store_unknown_chats_in_db', false)) {
-                $this->chat->name = Str::of("")
-                    ->append("[", $telegramChat->type(), ']')
-                    ->append(" ", $telegramChat->title());
+                $this->chat->name = $this->chatName($telegramChat);
                 $this->chat->save();
             }
         }
@@ -348,5 +346,12 @@ abstract class WebhookHandler
             ->push('/')
             ->map(fn (string $prefix) => str($prefix)->trim()->toString())
             ->unique();
+    }
+
+    protected function chatName(Chat $chat): string
+    {
+        return Str::of("")
+            ->append("[", $chat->type(), ']')
+            ->append(" ", $chat->title());
     }
 }

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -293,8 +293,7 @@ abstract class WebhookHandler
             }
 
             if (config('telegraph.security.store_unknown_chats_in_db', false)) {
-                $this->chat->name = $this->chatName($telegramChat);
-                $this->chat->save();
+                $this->createChat($telegramChat, $this->chat);
             }
         }
     }
@@ -346,6 +345,12 @@ abstract class WebhookHandler
             ->push('/')
             ->map(fn (string $prefix) => str($prefix)->trim()->toString())
             ->unique();
+    }
+
+    protected function createChat(Chat $telegramChat, TelegraphChat $chat): void
+    {
+        $chat->name = $this->chatName($telegramChat);
+        $chat->save();
     }
 
     protected function chatName(Chat $chat): string

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -349,11 +349,11 @@ abstract class WebhookHandler
 
     protected function createChat(Chat $telegramChat, TelegraphChat $chat): void
     {
-        $chat->name = $this->chatName($telegramChat);
+        $chat->name = $this->getChatName($telegramChat);
         $chat->save();
     }
 
-    protected function chatName(Chat $chat): string
+    protected function getChatName(Chat $chat): string
     {
         return Str::of("")
             ->append("[", $chat->type(), ']')


### PR DESCRIPTION
The current version of the code hardcodes the name of the chat when saving to the database. For example, `[supergroup] Foo`.

This is inconvenient when you need to display the list of channels without prefixes.

In such cases we have to create casts for the `name` field of the model to apply a regular expression to remove the prefix.

To solve this problem, I propose to consider two interrelated actions at once:

1. Put the formation of the chat name into an external protected method that developers can easily override to change the logic.
2. also put the method of chat creation into an external method in case some of the developers need to add their own logic when saving, having access to the `DefStudio\Telegraph\DTO\Chat` object.