### PR TITLE
Adding reaction processing when retrieving in webhooks

### DIFF
--- a/config/telegraph.php
+++ b/config/telegraph.php
@@ -60,6 +60,16 @@ return [
          */
         'max_connections' => env('TELEGRAPH_WEBHOOK_MAX_CONNECTIONS', 40),
 
+        /**
+         * List of event types for which the webhook should fire.
+         *
+         * Specify a null to receive all update types except `chat_member`, `message_reaction`,
+         * and `message_reaction_count` (by default).
+         *
+         * @see https://core.telegram.org/bots/api#setwebhook
+         */
+        'allowed_updates' => null,
+
         /*
          * If enabled, Telegraph dumps received
          * webhook messages to logs

--- a/docs/15.webhooks/4.webhook-request-types.md
+++ b/docs/15.webhooks/4.webhook-request-types.md
@@ -4,7 +4,7 @@ navigation.title: 'Request Types'
 ---
 
 
-Telegraph can handle four incoming webhook request types: **Chat Messages**,  **Chat Commands**, **Callback Queries** and **Inline Queries**:
+Telegraph can handle four incoming webhook request types: **Chat Messages**, **Message Reactions**, **Chat Commands**, **Callback Queries** and **Inline Queries**:
 
 ## Chat Messages
 
@@ -46,6 +46,27 @@ class CustomWebhookHandler extends WebhookHandler
 }
 ```
 
+## Message Reactions
+
+Chat messages containing adding and/or deleting user reactions (emojis) to messages.
+
+It can be handled by overriding `DefStudio\Telegraph\Handlers\WebhookHandler::handleChatReaction()` method:
+
+```php
+class CustomWebhookHandler extends WebhookHandler
+{
+    protected function handleChatReaction(array $newReactions, array $oldReactions): void
+    {
+        // in this example, a received emoji message is sent back to the chat
+        $this->chat->html("Received: " . $newReactions[0]['emoji'])->send();
+    }
+}
+```
+
+> [!WARNING]
+> By default, Telegram does not report events related to reactions to messages.
+> To interact with reactions, [specify](config/telegraph.php) in the settings all
+> [types of messages](https://core.telegram.org/bots/api#update) for which you want to catch events.
 
 ## Chat Commands
 

--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -29,7 +29,7 @@ trait InteractsWithWebhooks
         return $customWebhookUrl.route('telegraph.webhook', $this->getBot(), false);
     }
 
-    public function registerWebhook(bool $dropPendingUpdates = null, int $maxConnections = null, string $secretToken = null): Telegraph
+    public function registerWebhook(bool $dropPendingUpdates = null, int $maxConnections = null, string $secretToken = null, array $allowedUpdates = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -39,6 +39,7 @@ trait InteractsWithWebhooks
             'drop_pending_updates' => $dropPendingUpdates,
             'max_connections' => $maxConnections ?? config('telegraph.webhook.max_connections'),
             'secret_token' => $secretToken ?? config('telegraph.webhook.secret_token'),
+            'allowed_updates' => $allowedUpdates,
         ])->filter()
             ->toArray();
 

--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -39,7 +39,7 @@ trait InteractsWithWebhooks
             'drop_pending_updates' => $dropPendingUpdates,
             'max_connections' => $maxConnections ?? config('telegraph.webhook.max_connections'),
             'secret_token' => $secretToken ?? config('telegraph.webhook.secret_token'),
-            'allowed_updates' => $allowedUpdates,
+            'allowed_updates' => $allowedUpdates ?? config('telegraph.webhook.allowed_updates'),
         ])->filter()
             ->toArray();
 

--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -29,6 +29,15 @@ trait InteractsWithWebhooks
         return $customWebhookUrl.route('telegraph.webhook', $this->getBot(), false);
     }
 
+    /**
+     * @param  bool|null  $dropPendingUpdates
+     * @param  int|null  $maxConnections
+     * @param  string|null  $secretToken
+     * @param  string[]|null  $allowedUpdates
+     *
+     * @throws \DefStudio\Telegraph\Exceptions\TelegramWebhookException
+     * @return \DefStudio\Telegraph\Telegraph
+     */
     public function registerWebhook(bool $dropPendingUpdates = null, int $maxConnections = null, string $secretToken = null, array $allowedUpdates = null): Telegraph
     {
         $telegraph = clone $this;

--- a/src/DTO/Reaction.php
+++ b/src/DTO/Reaction.php
@@ -28,6 +28,8 @@ class Reaction implements Arrayable
 
     private CarbonInterface $date;
 
+    private function __construct() {}
+
     /**
      * @param array{
      *     message_id: int,

--- a/src/DTO/Reaction.php
+++ b/src/DTO/Reaction.php
@@ -20,11 +20,15 @@ class Reaction implements Arrayable
 
     private ?User $from = null;
 
-    /* @phpstan-ignore-next-line */
-    private array $oldReactions = [];
+    /**
+     * @var array<array<string, string>>
+     */
+    private array $oldReaction = [];
 
-    /* @phpstan-ignore-next-line */
-    private array $newReactions = [];
+    /**
+     * @var array<array<string, string>>
+     */
+    private array $newReaction = [];
 
     private CarbonInterface $date;
 
@@ -64,8 +68,8 @@ class Reaction implements Arrayable
 
         $reaction->date = Carbon::createFromTimestamp($data['date']);
 
-        $reaction->oldReactions = $data['old_reaction'];
-        $reaction->newReactions = $data['new_reaction'];
+        $reaction->oldReaction = $data['old_reaction'];
+        $reaction->newReaction = $data['new_reaction'];
 
         return $reaction;
     }
@@ -90,14 +94,20 @@ class Reaction implements Arrayable
         return $this->from;
     }
 
-    public function oldReactions(): array
+    /**
+     * @return array<array<string, string>>
+     */
+    public function oldReaction(): array
     {
-        return $this->oldReactions;
+        return $this->oldReaction;
     }
 
-    public function newReactions(): array
+    /**
+     * @return array<array<string, string>>
+     */
+    public function newReaction(): array
     {
-        return $this->newReactions;
+        return $this->newReaction;
     }
 
     public function date(): CarbonInterface
@@ -112,8 +122,8 @@ class Reaction implements Arrayable
             'chat' => $this->chat->toArray(),
             'actor_chat' => $this->actorChat?->toArray(),
             'from' => $this->from?->toArray(),
-            'old_reaction' => $this->oldReactions,
-            'new_reaction' => $this->newReactions,
+            'old_reaction' => $this->oldReaction,
+            'new_reaction' => $this->newReaction,
             'date' => $this->date->toISOString(),
         ], fn ($value) => $value !== null);
     }

--- a/src/DTO/Reaction.php
+++ b/src/DTO/Reaction.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefStudio\Telegraph\DTO;
+
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Carbon;
+
+/**
+ * @implements Arrayable<string, string|int|bool|array<string, mixed>>
+ */
+class Reaction implements Arrayable
+{
+    private int $id;
+
+    private Chat $chat;
+    private ?Chat $actorChat = null;
+
+    private ?User $from = null;
+
+    /* @phpstan-ignore-next-line */
+    private array $oldReactions = [];
+
+    /* @phpstan-ignore-next-line */
+    private array $newReactions = [];
+
+    private CarbonInterface $date;
+
+    /**
+     * @param array{
+     *     message_id: int,
+     *     chat: array<string, mixed>,
+     *     actor_chat?: array<string, mixed>,
+     *     user?: array<string, mixed>,
+     *     date: int,
+     *     old_reaction: array<int, array<string, string>>,
+     *     new_reaction: array<int, array<string, string>>
+     *  } $data
+     */
+    public static function fromArray(array $data): Reaction
+    {
+        $reaction = new self();
+
+        $reaction->id = $data['message_id'];
+
+        /* @phpstan-ignore-next-line */
+        $reaction->chat = Chat::fromArray($data['chat']);
+
+        if (isset($data['actor_chat'])) {
+            /* @phpstan-ignore-next-line */
+            $reaction->actorChat = Chat::fromArray($data['actor_chat']);
+        }
+
+        if (isset($data['user'])) {
+            /* @phpstan-ignore-next-line */
+            $reaction->from = User::fromArray($data['user']);
+        }
+
+        $reaction->date = Carbon::createFromTimestamp($data['date']);
+
+        $reaction->oldReactions = $data['old_reaction'];
+        $reaction->newReactions = $data['new_reaction'];
+
+        return $reaction;
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function chat(): Chat
+    {
+        return $this->chat;
+    }
+
+    public function actorChat(): ?Chat
+    {
+        return $this->actorChat;
+    }
+
+    public function from(): ?User
+    {
+        return $this->from;
+    }
+
+    public function oldReactions(): array
+    {
+        return $this->oldReactions;
+    }
+
+    public function newReactions(): array
+    {
+        return $this->newReactions;
+    }
+
+    public function date(): CarbonInterface
+    {
+        return $this->date;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'id' => $this->id,
+            'chat' => $this->chat->toArray(),
+            'actor_chat' => $this->actorChat?->toArray(),
+            'from' => $this->from?->toArray(),
+            'old_reaction' => $this->oldReactions,
+            'new_reaction' => $this->newReactions,
+            'date' => $this->date->toISOString(),
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/DTO/Reaction.php
+++ b/src/DTO/Reaction.php
@@ -28,7 +28,9 @@ class Reaction implements Arrayable
 
     private CarbonInterface $date;
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * @param array{

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -42,7 +42,7 @@ abstract class WebhookHandler
     protected CallbackQuery|null $callbackQuery = null;
 
     /**
-     * @var Collection<string, string>
+     * @var Collection(<string, string>|<int, <array<string, string>>>)
      */
     protected Collection $data;
 
@@ -142,7 +142,7 @@ abstract class WebhookHandler
         }
 
         /** @phpstan-ignore-next-line */
-        $this->handleChatReaction($this->reaction->newReactions(), $this->reaction->oldReactions());
+        $this->handleChatReaction($this->reaction->newReaction(), $this->reaction->oldReaction());
     }
 
     protected function canHandle(string $action): bool
@@ -200,7 +200,7 @@ abstract class WebhookHandler
 
         $this->messageId = $this->reaction->id();
 
-        $this->data = collect($this->reaction->newReactions());
+        $this->data = collect($this->reaction->newReaction());
     }
 
     protected function handleChatMemberJoined(User $member): void
@@ -218,6 +218,12 @@ abstract class WebhookHandler
         // .. do nothing
     }
 
+    /**
+     * @param  array<array<string, string>>  $newReactions
+     * @param  array<array<string, string>>  $oldReactions
+     *
+     * @return void
+     */
     protected function handleChatReaction(array $newReactions, array $oldReactions): void
     {
         // .. do nothing
@@ -341,7 +347,8 @@ abstract class WebhookHandler
     protected function allowUnknownChat(): bool
     {
         return (bool) match (true) {
-            $this->message !== null => config('telegraph.security.allow_messages_from_unknown_chats', false),
+            $this->message !== null,
+            $this->reaction !== null => config('telegraph.security.allow_messages_from_unknown_chats', false),
             $this->callbackQuery != null => config('telegraph.security.allow_callback_queries_from_unknown_chats', false),
             default => false,
         };

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -106,6 +106,34 @@ function webhook_message($handler = TestWebhookHandler::class, array $message = 
     ]);
 }
 
+function webhook_message_reaction($handler = TestWebhookHandler::class, array $message = null): Request
+{
+    register_webhook_handler($handler);
+
+    return Request::create('', 'POST', [
+        'message_reaction' => $message ?? [
+                'chat' => [
+                    'id' => 3,
+                    'type' => 'a',
+                    'title' => 'b',
+                ],
+                'date' => 1727211008,
+                'user' => [
+                    'id' => 1,
+                    'first_name' => 'a',
+                ],
+                'message_id' => 2,
+                'new_reaction' => [
+                    [
+                        'type' => 'emoji',
+                        'emoji' => '👍',
+                    ],
+                ],
+                'old_reaction' => [],
+            ],
+    ]);
+}
+
 function webhook_request($action = 'invalid', $handler = TestWebhookHandler::class, int $chat_id = -123456789): Request
 {
     register_webhook_handler($handler);

--- a/tests/Support/TestWebhookHandler.php
+++ b/tests/Support/TestWebhookHandler.php
@@ -140,4 +140,12 @@ class TestWebhookHandler extends WebhookHandler
     {
         $this->chat->html("{$member->firstName()} just left")->send();
     }
+
+    protected function handleChatReaction(array $newReactions, array $oldReactions): void
+    {
+        $this->chat->html(implode(':', [
+            'New reaction is ' . $newReactions[0]['emoji'],
+            'Old reaction is ' . $oldReactions[0]['emoji'],
+        ]))->send();
+    }
 }

--- a/tests/Unit/DTO/ReactionTest.php
+++ b/tests/Unit/DTO/ReactionTest.php
@@ -2,12 +2,46 @@
 
 /** @noinspection PhpUnhandledExceptionInspection */
 
+use DefStudio\Telegraph\DTO\Chat;
 use DefStudio\Telegraph\DTO\Reaction;
+use DefStudio\Telegraph\DTO\User;
 use Illuminate\Support\Str;
 
 it('export all properties to array', function () {
     $dto = Reaction::fromArray([
-        // ...
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '🔥',
+            ],
+        ],
     ]);
 
     $array = $dto->toArray();
@@ -19,21 +53,208 @@ it('export all properties to array', function () {
 });
 
 it('extract chat info', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [],
+    ]);
 
+    expect($dto->chat())
+        ->toBeInstanceOf(Chat::class)
+        ->id()->toBe('3')
+        ->type()->toBe('a')
+        ->title()->toBe('b');
 });
 
 it('extract actor chat info', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [],
+    ]);
 
+    expect($dto->actorChat())
+        ->toBeInstanceOf(Chat::class)
+        ->id()->toBe('3')
+        ->type()->toBe('a')
+        ->title()->toBe('b');
 });
 
 it('extract from info', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [],
+    ]);
 
+    expect($dto->from())
+        ->toBeInstanceOf(User::class)
+        ->id()->toBe(1)
+        ->firstName()->toBe('a')
+        ->lastName()->toBe('b');
 });
 
 it('extract old_reaction info', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '🔥',
+            ],
+        ],
+    ]);
 
+    expect($dto->oldReaction())->toBe([
+        [
+            'type' => 'emoji',
+            'emoji' => '🔥',
+        ],
+    ]);
 });
 
 it('extract new_reaction info', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '🔥',
+            ],
+        ],
+    ]);
 
+    expect($dto->newReaction())->toBe([
+        [
+            'type' => 'emoji',
+            'emoji' => '👍',
+        ],
+    ]);
 });

--- a/tests/Unit/DTO/ReactionTest.php
+++ b/tests/Unit/DTO/ReactionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use DefStudio\Telegraph\DTO\Reaction;
+use Illuminate\Support\Str;
+
+it('export all properties to array', function () {
+    $dto = Reaction::fromArray([
+        // ...
+    ]);
+
+    $array = $dto->toArray();
+
+    $reflection = new ReflectionClass($dto);
+    foreach ($reflection->getProperties() as $property) {
+        expect($array)->toHaveKey(Str::of($property->name)->snake());
+    }
+});
+
+it('extract chat info', function () {
+
+});
+
+it('extract actor chat info', function () {
+
+});
+
+it('extract from info', function () {
+
+});
+
+it('extract old_reaction info', function () {
+
+});
+
+it('extract new_reaction info', function () {
+
+});

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -400,6 +400,51 @@ it('can handle a member left', function () {
     Facade::assertSent("Bob just left");
 });
 
+it('can handle a message reaction', function () {
+    Config::set('telegraph.security.allow_messages_from_unknown_chats', true);
+
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_message_reaction(message: [
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'actor_chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+            'language_code' => 'd',
+            'is_premium' => false,
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '👍',
+            ],
+        ],
+        'old_reaction' => [
+            [
+                'type' => 'emoji',
+                'emoji' => '🔥',
+            ],
+        ],
+    ]), $bot);
+
+    Facade::assertSent("New reaction is 👍:Old reaction is 🔥");
+});
+
 it('does not crash on errors', function () {
     $chat = chat();
 


### PR DESCRIPTION
By default Telegram sends all events except `chat_member`, `message_reaction`, and `message_reaction_count`.

Therefore, you need to explicitly set the required message types, such as `message_reaction`, to receive them.

Docs: https://core.telegram.org/bots/api#setwebhook

#### TODO:

- [x] Functional part
- [x] Adding tests
- [x] Update docs