### PR TITLE
Added entities processing

### DIFF
--- a/docs/12.features/9.dto.md
+++ b/docs/12.features/9.dto.md
@@ -42,6 +42,7 @@ contains incoming data (a message or a callback query)
 - `->contact()` (optional) an instance of [`Contact`](#contact) holding data about the contained contact data
 - `->voice()` (optional) an instance of [`Voice`](#voice) holding data about the contained voical message
 - `->sticker()` (optional) an instance of [`Sticker`](#sticker) holding data about the contained sticker
+- `->entities()` (optional) a collection of [`Entity`](#entity) holding data about the contained entity
 - `->newChatMembers()` a collection of [`User`](#user) holding the list of users that joined the group/supergroup
 - `->leftChatMember()` (optional) an instance of [`User`](#user) holding data about the user that left the group/supergroup
 - `->webAppData()` (optional) incoming data from sendData method of telegram WebApp
@@ -147,6 +148,16 @@ contains incoming data (a message or a callback query)
 - `->emoji()` 	(optional) emoji associated with the sticker
 - `->filesize()` (optional) sticker file size in Bytes
 - `->thumbnail()` (optional) an instance of the [`Photo`](#photo) that holds data about the thumbnail
+
+## `Entity`
+
+- `->type()` type of the entity
+- `->offset()` offset in UTF-16 code units to the start of the entity
+- `->length()` length of the entity in utf-16 code units
+- `->url()` (optional) for “text_link” only, URL that will be opened after user taps on the text
+- `->user()` (optional) for “text_mention” only, the mentioned [`User`](#user)
+- `->language()` (optional) for “pre” only, the programming language of the entity text
+- `->customEmojiId()` (optional) for “custom_emoji” only, unique identifier of the custom emoji
 
 ## `WriteAccessAllowed`
 

--- a/src/DTO/Entity.php
+++ b/src/DTO/Entity.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefStudio\Telegraph\DTO;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Entity implements Arrayable
+{
+    private string $type;
+
+    private int $offset;
+
+    private int $length;
+
+    private ?string $url = null;
+
+    private ?User $user = null;
+
+    private ?string $language = null;
+
+    private ?string $customEmojiId = null;
+
+    public static function fromArray(array $data): Entity
+    {
+        $entity = new self();
+
+        $entity->type = $data['type'];
+        $entity->offset = $data['offset'];
+        $entity->length = $data['length'];
+
+        if (isset($data['url'])) {
+            $entity->url = $data['url'];
+        }
+
+        if (isset($data['user'])) {
+            $entity->user = User::fromArray($data['user']);
+        }
+
+        if (isset($data['language'])) {
+            $entity->language = $data['language'];
+        }
+
+        if (isset($data['custom_emoji_id'])) {
+            $entity->customEmojiId = $data['custom_emoji_id'];
+        }
+
+        return $entity;
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function offset(): int
+    {
+        return $this->offset;
+    }
+
+    public function length(): int
+    {
+        return $this->length;
+    }
+
+    public function url(): ?string
+    {
+        return $this->url;
+    }
+
+    public function user(): ?User
+    {
+        return $this->user;
+    }
+
+    public function language(): ?string
+    {
+        return $this->language;
+    }
+
+    public function customEmojiId(): ?string
+    {
+        return $this->customEmojiId;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'type' => $this->type,
+            'offset' => $this->offset,
+            'length' => $this->length,
+            'url' => $this->url,
+            'user' => $this->user()?->toArray(),
+            'language' => $this->language,
+            'custom_emoji_id' => $this->customEmojiId,
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/DTO/Entity.php
+++ b/src/DTO/Entity.php
@@ -22,6 +22,10 @@ class Entity implements Arrayable
 
     private ?string $customEmojiId = null;
 
+    private function __construct()
+    {
+    }
+
     public static function fromArray(array $data): Entity
     {
         $entity = new self();

--- a/src/DTO/Entity.php
+++ b/src/DTO/Entity.php
@@ -6,6 +6,9 @@ namespace DefStudio\Telegraph\DTO;
 
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * @implements Arrayable<string, string|int|array<string, mixed>>
+ */
 class Entity implements Arrayable
 {
     private string $type;
@@ -26,6 +29,19 @@ class Entity implements Arrayable
     {
     }
 
+    /**
+     * @param array{
+     *     type: string,
+     *     offset: int,
+     *     length: int,
+     *     url?: string,
+     *     user?: array<string, mixed>,
+     *     language?: string,
+     *     custom_emoji_id?: string
+     * } $data
+     *
+     * @return \DefStudio\Telegraph\DTO\Entity
+     */
     public static function fromArray(array $data): Entity
     {
         $entity = new self();
@@ -39,6 +55,7 @@ class Entity implements Arrayable
         }
 
         if (isset($data['user'])) {
+            /* @phpstan-ignore-next-line */
             $entity->user = User::fromArray($data['user']);
         }
 

--- a/src/DTO/Message.php
+++ b/src/DTO/Message.php
@@ -341,7 +341,7 @@ class Message implements Arrayable
         return $this->writeAccessAllowed;
     }
 
-    public function entities(): ?Collection
+    public function entities(): Collection
     {
         return $this->entities;
     }
@@ -373,7 +373,7 @@ class Message implements Arrayable
             'left_chat_member' => $this->leftChatMember,
             'web_app_data' => $this->webAppData,
             'write_access_allowed' => $this->writeAccessAllowed?->toArray(),
-            'entities' => $this->entities?->toArray(),
+            'entities' => $this->entities->toArray(),
         ], fn ($value) => $value !== null);
     }
 }

--- a/src/DTO/Message.php
+++ b/src/DTO/Message.php
@@ -53,6 +53,9 @@ class Message implements Arrayable
 
     private ?WriteAccessAllowed $writeAccessAllowed = null;
 
+    /** @var Collection<Entity>|null */
+    private ?Collection $entities = null;
+
     private function __construct()
     {
         $this->photos = Collection::empty();
@@ -85,6 +88,7 @@ class Message implements Arrayable
      *     left_chat_member?: array<string, mixed>,
      *     web_app_data?: array<string, mixed>,
      *     write_access_allowed?: array<string, mixed>,
+     *     entities?: array<object>
      *  } $data
      */
     public static function fromArray(array $data): Message
@@ -200,6 +204,11 @@ class Message implements Arrayable
         if (isset($data['write_access_allowed'])) {
             /* @phpstan-ignore-next-line */
             $message->writeAccessAllowed = WriteAccessAllowed::fromArray($data['write_access_allowed']);
+        }
+
+        if (isset($data['entities'])) {
+            /* @phpstan-ignore-next-line */
+            $message->entities = collect($data['entities'])->map(fn (array $entity) => Entity::fromArray($entity));
         }
 
         return $message;
@@ -331,6 +340,11 @@ class Message implements Arrayable
         return $this->writeAccessAllowed;
     }
 
+    public function entities(): ?Collection
+    {
+        return $this->entities;
+    }
+
     public function toArray(): array
     {
         return array_filter([
@@ -358,6 +372,7 @@ class Message implements Arrayable
             'left_chat_member' => $this->leftChatMember,
             'web_app_data' => $this->webAppData,
             'write_access_allowed' => $this->writeAccessAllowed?->toArray(),
+            'entities' => $this->entities?->toArray(),
         ], fn ($value) => $value !== null);
     }
 }

--- a/src/DTO/Message.php
+++ b/src/DTO/Message.php
@@ -206,7 +206,7 @@ class Message implements Arrayable
             $message->writeAccessAllowed = WriteAccessAllowed::fromArray($data['write_access_allowed']);
         }
 
-        if (isset($data['entities'])) {
+        if (isset($data['entities']) && $data['entities']) {
             /* @phpstan-ignore-next-line */
             $message->entities = collect($data['entities'])->map(fn (array $entity) => Entity::fromArray($entity));
         }

--- a/src/DTO/Message.php
+++ b/src/DTO/Message.php
@@ -53,12 +53,13 @@ class Message implements Arrayable
 
     private ?WriteAccessAllowed $writeAccessAllowed = null;
 
-    /** @var Collection<Entity>|null */
-    private ?Collection $entities = null;
+    /** @var Collection<array-key, Entity> */
+    private Collection $entities;
 
     private function __construct()
     {
         $this->photos = Collection::empty();
+        $this->entities = Collection::empty();
     }
 
     /**

--- a/tests/.pest/snapshots/Unit/Models/TelegraphBotTest/it_can_poll_for_updates.snap
+++ b/tests/.pest/snapshots/Unit/Models/TelegraphBotTest/it_can_poll_for_updates.snap
@@ -53,7 +53,8 @@
                 "title": "Bot Test Chat"
             },
             "photos": [],
-            "new_chat_members": []
+            "new_chat_members": [],
+            "entities": []
         }
     }
 ]

--- a/tests/.pest/snapshots/Unit/Models/TelegraphBotTest/it_can_poll_for_updates.snap
+++ b/tests/.pest/snapshots/Unit/Models/TelegraphBotTest/it_can_poll_for_updates.snap
@@ -21,7 +21,14 @@
                 "title": "john_smith"
             },
             "photos": [],
-            "new_chat_members": []
+            "new_chat_members": [],
+            "entities": [
+                {
+                    "type": "bot_command",
+                    "offset": 0,
+                    "length": 6
+                }
+            ]
         }
     },
     {

--- a/tests/Support/TestEntitiesWebhookHandler.php
+++ b/tests/Support/TestEntitiesWebhookHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefStudio\Telegraph\Tests\Support;
+
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+use Illuminate\Support\Stringable;
+
+class TestEntitiesWebhookHandler extends WebhookHandler
+{
+    protected function handleChatMessage(Stringable $text): void
+    {
+        /** @var \DefStudio\Telegraph\DTO\Entity $entity */
+        $entity = $this->message->entities()->first();
+
+        $fromText = $text->substr($entity->offset(), $entity->length());
+        $fromEntity = $entity->url();
+
+        $this->chat->html(implode('. ', [
+            'URL from text: ' . $fromText,
+            'URL from entity: ' . $fromEntity,
+        ]))->send();
+    }
+}

--- a/tests/Unit/DTO/EntityTest.php
+++ b/tests/Unit/DTO/EntityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use DefStudio\Telegraph\DTO\Entity;
+use DefStudio\Telegraph\DTO\Message;
+use Illuminate\Support\Str;
+
+it('export all properties to array', function () {
+    $dto = Message::fromArray([
+        'message_id' => 2,
+        'date' => now()->timestamp,
+        'entities' => [
+            [
+                'type' => 'url',
+                'offset' => 10,
+                'length' => 19,
+                'url' => 'https://example.com',
+                'user' => [
+                    'id' => 1,
+                    'is_bot' => true,
+                    'first_name' => 'a',
+                    'last_name' => 'b',
+                    'username' => 'c',
+                    'language_code' => 'd',
+                    'is_premium' => false,
+                ],
+                'language' => 'en',
+                'custom_emoji_id' => '12345',
+            ],
+        ],
+    ]);
+
+    $array = $dto->entities()->first()->toArray();
+
+    $reflection = new ReflectionClass(Entity::class);
+    foreach ($reflection->getProperties() as $property) {
+        expect($array)->toHaveKey(Str::of($property->name)->snake());
+    }
+});

--- a/tests/Unit/DTO/MessageTest.php
+++ b/tests/Unit/DTO/MessageTest.php
@@ -289,6 +289,14 @@ it('export all properties to array', function () {
             "web_app_name" => "test",
             "from_attachment_menu" => true,
         ],
+        'entities' => [
+            [
+                'type' => 'url',
+                'offset' => 4,
+                'length' => 19,
+                'url' => 'https://example.com',
+            ],
+        ],
     ]);
 
     $array = $dto->toArray();

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -5,6 +5,7 @@
 
 use DefStudio\Telegraph\Facades\Telegraph as Facade;
 use DefStudio\Telegraph\Telegraph;
+use DefStudio\Telegraph\Tests\Support\TestEntitiesWebhookHandler;
 use DefStudio\Telegraph\Tests\Support\TestWebhookHandler;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -431,18 +432,47 @@ it('can handle a message reaction', function () {
         'new_reaction' => [
             [
                 'type' => 'emoji',
-                'emoji' => '👍',
+                'emoji' => '??',
             ],
         ],
         'old_reaction' => [
             [
                 'type' => 'emoji',
-                'emoji' => '🔥',
+                'emoji' => '??',
             ],
         ],
     ]), $bot);
 
-    Facade::assertSent("New reaction is 👍:Old reaction is 🔥");
+    Facade::assertSent("New reaction is ??:Old reaction is ??");
+});
+
+it('can handle a message entities', function () {
+    $bot = bot();
+    Facade::fake();
+
+    app(TestEntitiesWebhookHandler::class)->handle(webhook_message(TestEntitiesWebhookHandler::class, [
+        'message_id' => 123456,
+        'chat' => [
+            'id' => -123456789,
+            'type' => 'group',
+            'title' => 'Test chat',
+        ],
+        'date' => 1646516736,
+        'text' => 'foo https://example.com bar',
+        'entities' => [
+            [
+                'type' => 'url',
+                'offset' => 4,
+                'length' => 19,
+                'url' => 'https://example.com',
+            ],
+        ],
+    ]), $bot);
+
+    Facade::assertSent(implode('. ', [
+        'URL from text: https://example.com',
+        'URL from entity: https://example.com',
+    ]));
 });
 
 it('does not crash on errors', function () {

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -432,18 +432,18 @@ it('can handle a message reaction', function () {
         'new_reaction' => [
             [
                 'type' => 'emoji',
-                'emoji' => '??',
+                'emoji' => '👍',
             ],
         ],
         'old_reaction' => [
             [
                 'type' => 'emoji',
-                'emoji' => '??',
+                'emoji' => '🔥',
             ],
         ],
     ]), $bot);
 
-    Facade::assertSent("New reaction is ??:Old reaction is ??");
+    Facade::assertSent("New reaction is 👍:Old reaction is 🔥");
 });
 
 it('can handle a message entities', function () {


### PR DESCRIPTION
Message entities can provide a lot of useful information. For example:

- mention
- hashtag
- cashtag
- bot_command
- url
- email
- phone_number
- bold
- italic
- underline
- strikethrough
- spoiler
- blockquote
- expandable_blockquote
- code
- pre
- text_link
- text_mention
- custom_emoji

In other words, they contain not only rules for styling messages, but also useful data. For example, a phone number, link or hashtag found in the message body, based on which the application can apply certain rules of message processing.

Documentation: https://core.telegram.org/bots/api#messageentity