### PR TITLE
Fix detection of command parameter without passing it

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -370,14 +370,18 @@ abstract class WebhookHandler
      */
     protected function parseCommand(Stringable $text): array
     {
-        $command = (string) $text->before('@')->before(' ');
-        $parameter = (string) $text->after('@')->after(' ');
+        $command = $text->before('@')->before(' ');
 
-        $this->commandPrefixes()->each(function (string $value) use (&$command) {
-            $command = str($command)->after($value)->toString();
-        });
+        foreach ($this->commandPrefixes() as $prefix) {
+            if ($command->startsWith($prefix)) {
+                $parameter = $text->after($command)->after('@')->after(' ');
+                $command = $command->after($prefix);
 
-        return [$command, $parameter];
+                break;
+            }
+        }
+
+        return [(string) $command, (string) ($parameter ?? '')];
     }
 
     /**

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -235,6 +235,15 @@ it('can handle a command with custom start char', function () {
     Facade::assertSent("Hello!! your parameter is [foo bot : :]");
 });
 
+it('can handle a command without parameter', function () {
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_command('/hello'), $bot);
+
+    Facade::assertSent("Hello!!");
+});
+
 it('cannot handle a command with custom start char', function () {
     $bot = bot();
     Facade::fake();


### PR DESCRIPTION
This PR fixes an error when a command is passed without parameters, such as `/foo`. In this case, the parameter will be `/foo` and the command name will be `foo`.

As a bonus, the command eliminates processing all other prefixes from the array when the right one is found.

Examples:

### Correct
```json
{
    "message": {
        "chat": { "id": -111, "type": "supergroup", "title": "Test Group" },
        "date": 1727723329,
        "from": { "id": 222, "is_bot": false, "last_name": "Doe", "first_name": "John" },
        "text": "/foo bar",
        "entities": [
            { "type": "bot_command", "length": 4, "offset": 0 }
        ],
        "message_id": 1854
    },
    "update_id": 1
}
```
```
Hello!! your parameter is [bar]
```

### Incorrect
```json
{
    "message": {
        "chat": { "id": -111, "type": "supergroup", "title": "Test Group" },
        "date": 1727723329,
        "from": { "id": 222, "is_bot": false, "last_name": "Doe", "first_name": "John" },
        "text": "/foo",
        "entities": [
            { "type": "bot_command", "length": 4, "offset": 0 }
        ],
        "message_id": 1854
    },
    "update_id": 1
}
```
```
Hello!! your parameter is [/foo]
```