### PR TITLE
TypeError: Cannot assign int to property `Entity::$customEmojiId` of type ?string

### DIFF
--- a/src/DTO/Entity.php
+++ b/src/DTO/Entity.php
@@ -64,7 +64,7 @@ class Entity implements Arrayable
         }
 
         if (isset($data['custom_emoji_id'])) {
-            $entity->customEmojiId = $data['custom_emoji_id'];
+            $entity->customEmojiId = (string) $data['custom_emoji_id'];
         }
 
         return $entity;


### PR DESCRIPTION
Interesting point - the documentation says this field is a string, but the webhook comes up with an integer:

```json
{
  "message":{
    "text":"💗 foo",
    "entities":[
      {
        "type":"custom_emoji",
        "length":2,
        "offset":0,
        "custom_emoji_id":5364201435858744869
      }
    ],
    "message_id":68753
  },
  "update_id":577883599
}
```
_I removed the extra fields so they wouldn't be distracting._

Since I'd rather stick to the official documentation, I specified a conversion to a string when assigning the identifier.