### PR TITLE
fix error in Keyboard::fromArray() method if InlineKeyboardButton button has empty query string

### DIFF
--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -85,11 +85,11 @@ class Keyboard implements Arrayable
                 }
 
                 if (array_key_exists('switch_inline_query', $button)) {
-                    $rowButton = $rowButton->switchInlineQuery($button['switch_inline_query']);
+                    $rowButton = $rowButton->switchInlineQuery($button['switch_inline_query'] ?? '');
                 }
 
                 if (array_key_exists('switch_inline_query_current_chat', $button)) {
-                    $rowButton = $rowButton->switchInlineQuery($button['switch_inline_query_current_chat'])->currentChat();
+                    $rowButton = $rowButton->switchInlineQuery($button['switch_inline_query_current_chat'] ?? '')->currentChat();
                 }
 
                 $rowButtons[] = $rowButton;


### PR DESCRIPTION
Telegram swap empty query string with null value for InlineKeyboardButton. When you send switch_inline_query_current_chat='', on Callback you receive data with button with switch_inline_query_current_chat=null.

https://github.com/defstudio/telegraph/issues/658