### PR TITLE
fix: Implicitly nullable parameter types in php8.4

### DIFF
--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -28,7 +28,7 @@ trait ComposesMessages
         $this->data['chat_id'] = $this->getChatId();
     }
 
-    public function html(string $message = null): Telegraph
+    public function html(?string $message = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -41,7 +41,7 @@ trait ComposesMessages
         return $telegraph;
     }
 
-    public function markdown(string $message = null): Telegraph
+    public function markdown(?string $message = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -54,7 +54,7 @@ trait ComposesMessages
         return $telegraph;
     }
 
-    public function markdownV2(string $message = null): Telegraph
+    public function markdownV2(?string $message = null): Telegraph
     {
         $telegraph = clone $this;
 

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -128,7 +128,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function createForumTopic(string $name, int $iconColor = null, string $iconCustomEmojiId = null): Telegraph
+    public function createForumTopic(string $name, ?int $iconColor = null, ?string $iconCustomEmojiId = null): Telegraph
     {
         $telegraph = clone $this;
         $telegraph->endpoint = self::ENDPOINT_CREATE_FORUM_TOPIC;
@@ -146,7 +146,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function editForumTopic(int $threadId = null, string $name = null, string $iconCustomEmojiId = null): Telegraph
+    public function editForumTopic(?int $threadId = null, ?string $name = null, ?string $iconCustomEmojiId = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -172,7 +172,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function closeForumTopic(int $threadId = null): Telegraph
+    public function closeForumTopic(?int $threadId = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -189,7 +189,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function reopenForumTopic(int $threadId = null): Telegraph
+    public function reopenForumTopic(?int $threadId = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -206,7 +206,7 @@ trait HasBotsAndChats
         return $telegraph;
     }
 
-    public function deleteForumTopic(int $threadId = null): Telegraph
+    public function deleteForumTopic(?int $threadId = null): Telegraph
     {
         $telegraph = clone $this;
 
@@ -235,7 +235,7 @@ trait HasBotsAndChats
     /**
      * @param string[]|null $allowedUpdates
      */
-    public function botUpdates(int $timeout = null, int $offset = null, int $limit = null, array $allowedUpdates = null): Telegraph
+    public function botUpdates(?int $timeout = null, ?int $offset = null, ?int $limit = null, ?array $allowedUpdates = null): Telegraph
     {
         $telegraph = clone $this;
 

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -70,7 +70,7 @@ trait InteractsWithTelegram
         return $data;
     }
 
-    protected function dispatchRequestToTelegram(string $queue = null): PendingDispatch
+    protected function dispatchRequestToTelegram(?string $queue = null): PendingDispatch
     {
         return SendRequestToTelegramJob::dispatch($this->getApiUrl(), $this->prepareData(), $this->files)->onQueue($queue);
     }

--- a/src/Concerns/InteractsWithWebhooks.php
+++ b/src/Concerns/InteractsWithWebhooks.php
@@ -38,7 +38,7 @@ trait InteractsWithWebhooks
      * @throws \DefStudio\Telegraph\Exceptions\TelegramWebhookException
      * @return \DefStudio\Telegraph\Telegraph
      */
-    public function registerWebhook(bool $dropPendingUpdates = null, int $maxConnections = null, string $secretToken = null, array $allowedUpdates = null): Telegraph
+    public function registerWebhook(?bool $dropPendingUpdates = null, ?int $maxConnections = null, ?string $secretToken = null, ?array $allowedUpdates = null): Telegraph
     {
         $telegraph = clone $this;
 

--- a/src/Concerns/SendsAttachments.php
+++ b/src/Concerns/SendsAttachments.php
@@ -91,7 +91,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function voice(string $path, string $filename = null): self
+    public function voice(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -111,7 +111,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function animation(string $path, string $filename = null): self
+    public function animation(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -125,7 +125,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function video(string $path, string $filename = null): self
+    public function video(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -139,7 +139,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function audio(string $path, string $filename = null): self
+    public function audio(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -153,7 +153,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function document(string $path, string $filename = null): self
+    public function document(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -223,7 +223,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function photo(string $path, string $filename = null): self
+    public function photo(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 
@@ -291,7 +291,7 @@ trait SendsAttachments
         return ceil($sizeInKBytes * 100) / 100;
     }
 
-    public function dice(string $emoji = null): self
+    public function dice(?string $emoji = null): self
     {
         $telegraph = clone $this;
 
@@ -305,7 +305,7 @@ trait SendsAttachments
         return $telegraph;
     }
 
-    public function sticker(string $path, string $filename = null): self
+    public function sticker(string $path, ?string $filename = null): self
     {
         $telegraph = clone $this;
 

--- a/src/Concerns/StoresFiles.php
+++ b/src/Concerns/StoresFiles.php
@@ -24,7 +24,7 @@ trait StoresFiles
         return $telegraph;
     }
 
-    public function store(Downloadable|string $downloadable, string $path, string $filename = null): string
+    public function store(Downloadable|string $downloadable, string $path, ?string $filename = null): string
     {
         $fileId = is_string($downloadable) ? $downloadable : $downloadable->id();
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c33c65f-b236-420c-b318-7533f657055a)
PHP 8.4 deprecates implicitly nullable parameter types. This update explicitly declares nullable types (`?type`) to ensure compatibility and eliminate deprecation warnings.

