### PR TITLE
Fixed Undefined array key "emoji"

### DIFF
--- a/src/DTO/ReactionType.php
+++ b/src/DTO/ReactionType.php
@@ -16,7 +16,7 @@ class ReactionType implements Arrayable
     public const TYPE_PAID_EMOJI = 'paid';
 
     private string $type;
-    private string $emoji;
+    private ?string $emoji = null;
     private ?string $customEmojiId = null;
 
     private function __construct()
@@ -35,7 +35,7 @@ class ReactionType implements Arrayable
         $reaction = new self();
 
         $reaction->type = $data['type'];
-        $reaction->emoji = $data['emoji'];
+        $reaction->emoji = $data['emoji'] ?? null;
         $reaction->customEmojiId = $data['custom_emoji_id'] ?? null;
 
         return $reaction;
@@ -46,7 +46,7 @@ class ReactionType implements Arrayable
         return $this->type;
     }
 
-    public function emoji(): string
+    public function emoji(): ?string
     {
         return $this->emoji;
     }

--- a/tests/Unit/DTO/ReactionTest.php
+++ b/tests/Unit/DTO/ReactionTest.php
@@ -7,7 +7,7 @@ use DefStudio\Telegraph\DTO\Reaction;
 use DefStudio\Telegraph\DTO\User;
 use Illuminate\Support\Str;
 
-it('export all properties to array', function () {
+test('export all properties to array', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -52,7 +52,7 @@ it('export all properties to array', function () {
     }
 });
 
-it('extract chat info', function () {
+test('extract chat info', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -91,7 +91,7 @@ it('extract chat info', function () {
         ->title()->toBe('b');
 });
 
-it('extract actor chat info', function () {
+test('extract actor chat info', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -130,7 +130,7 @@ it('extract actor chat info', function () {
         ->title()->toBe('b');
 });
 
-it('extract from info', function () {
+test('extract from info', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -169,7 +169,7 @@ it('extract from info', function () {
         ->lastName()->toBe('b');
 });
 
-it('extract old_reaction info', function () {
+test('extract old_reaction info', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -214,7 +214,7 @@ it('extract old_reaction info', function () {
     ]);
 });
 
-it('extract new_reaction info', function () {
+test('extract new_reaction info', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,
@@ -259,7 +259,7 @@ it('extract new_reaction info', function () {
     ]);
 });
 
-it('only custom reaction', function () {
+test('only custom reaction', function () {
     $dto = Reaction::fromArray([
         'chat' => [
             'id' => 3,

--- a/tests/Unit/DTO/ReactionTest.php
+++ b/tests/Unit/DTO/ReactionTest.php
@@ -258,3 +258,41 @@ it('extract new_reaction info', function () {
         ],
     ]);
 });
+
+it('only custom reaction', function () {
+    $dto = Reaction::fromArray([
+        'chat' => [
+            'id' => 3,
+            'type' => 'a',
+            'title' => 'b',
+        ],
+        'date' => 1727211008,
+        'user' => [
+            'id' => 1,
+            'is_bot' => false,
+            'first_name' => 'a',
+            'last_name' => 'b',
+            'username' => 'c',
+        ],
+        'message_id' => 2,
+        'new_reaction' => [
+            [
+                'type' => 'emoji',
+                'custom_emoji_id' => '123',
+            ],
+        ],
+        'old_reaction' => [
+            [
+                'type' => 'emoji',
+                'custom_emoji_id' => '456',
+            ],
+        ],
+    ]);
+
+    expect($dto->newReaction()->toArray())->toBe([
+        [
+            'type' => 'emoji',
+            'custom_emoji_id' => '123',
+        ],
+    ]);
+});


### PR DESCRIPTION
Ran into an issue today where Telegram sent the `custom_emoji_id` property without `emoji`:

```json
{
  "update_id":61801077,
  "message_reaction":{
    "chat":{
      "id":-1002362140004,
      "title":"Ковёр не самолёт",
      "username":"covernesamolet",
      "type":"supergroup"
    },
    "message_id":3794,
    "user":{
      "id":107679035,
      "is_bot":false,
      "first_name":"Dalert",
      "last_name":"Zart Okderin",
      "username":"DalertDragon",
      "is_premium":true
    },
    "date":1734843802,
    "old_reaction":[],
    "new_reaction":[
      {
        "type":"custom_emoji",
        "custom_emoji_id":"5425057201137918413"
      }
    ]
  }
}
```

This PR fixes that problem.