### PR TITLE
Add forwarded message handling

### DIFF
--- a/docs/15.webhooks/4.webhook-request-types.md
+++ b/docs/15.webhooks/4.webhook-request-types.md
@@ -275,3 +275,21 @@ Used DTOs:
 - User ([`DefStudio\Telegraph\DTO\User`](../12.features/9.dto.md#user))
 - Chat ([`DefStudio\Telegraph\DTO\Chat`](../12.features/9.dto.md#chat))
 - ChatJoinRequest ([`DefStudio\Telegraph\DTO\ChatJoinRequest`](../12.features/9.dto.md#chatjoinrequest))
+
+
+## Forwarded Messages
+
+Telegraph bots can also handle forwarded messages from other chats or channels. This can be useful for tracking or responding to messages that have been forwarded to the bot's chat.
+
+To handle forwarded messages, you can override the `handleForwardedMessage` method in your custom webhook handler:
+
+```php
+class CustomWebhookHandler extends WebhookHandler
+{
+    protected function handleForwardedMessage(array $rawMessage): void
+    {
+        // In this example, the bot sends a confirmation message when a message is forwarded
+        $this->chat->html("Message just forwarded")->send();
+    }
+}
+```

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -133,6 +133,12 @@ abstract class WebhookHandler
             return;
         }
 
+        $rawMessage = $this->request->input('message');
+        if (isset($rawMessage['forward_from_chat'])) {
+            $this->handleForwardedMessage($rawMessage);
+            return;
+        }
+
         $this->handleChatMessage($text);
     }
 
@@ -217,6 +223,11 @@ abstract class WebhookHandler
     }
 
     protected function handleChatMessage(Stringable $text): void
+    {
+        // .. do nothing
+    }
+
+    protected function handleForwardedMessage(array $rawMessage): void
     {
         // .. do nothing
     }

--- a/tests/Support/TestWebhookHandler.php
+++ b/tests/Support/TestWebhookHandler.php
@@ -142,6 +142,10 @@ class TestWebhookHandler extends WebhookHandler
     {
         $this->chat->html("{$member->firstName()} just left")->send();
     }
+    protected function handleForwardedMessage(array $rawMessage): void
+    {
+        $this->chat->html("message just forwarded. with message-id: ".$rawMessage['message_id'])->send();
+    }
 
     protected function handleChatJoinRequest(ChatJoinRequest $chatJoinRequest): void
     {

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -419,6 +419,29 @@ it('can handle a chat join request', function () {
     Facade::assertChatJoinRequestApproved(2);
 });
 
+it('can handle forwarded message', function () {
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_message(message: [
+        'message_id' => 123456,
+        'chat' => [
+            'id' => -123456789,
+            'type' => 'group',
+            'title' => 'Test chat',
+        ],
+        'date' => 1646516736,
+        'forward_from_chat' => [
+            'id' => -987654321,
+            'type' => 'channel',
+            'title' => 'Test Channel',
+        ],
+        'text' => 'This is a forwarded message',
+    ]), $bot);
+
+    Facade::assertSent("message just forwarded. with message-id: 123456");
+});
+
 it('can handle a message reaction', function () {
     Config::set('telegraph.security.allow_messages_from_unknown_chats', true);
 


### PR DESCRIPTION
I wanted to get notice on my telegram bot when a message just forwarded. so i created a new handler method named `forwardedmessage` witch can use in webhook handler.