### PR TITLE
Fix error in DefStudio\Telegraph\Client\TelegraphResponse dump() and dd() methods declaration

### DIFF
--- a/src/Client/TelegraphResponse.php
+++ b/src/Client/TelegraphResponse.php
@@ -31,9 +31,9 @@ class TelegraphResponse extends Response
         return (int) $this->json('result.message_id');
     }
 
-    public function dump(): static
+    public function dump($key = null): static
     {
-        dump($this->json());
+        dump($this->json($key));
 
         return $this;
     }
@@ -41,8 +41,8 @@ class TelegraphResponse extends Response
     /**
      * @return never-returns
      */
-    public function dd(): void
+    public function dd($key = null): void
     {
-        dd($this->json());
+        dd($this->json($key));
     }
 }


### PR DESCRIPTION
Methods dump and dd with $key parameter were added in Laravel 11 in Illuminate\Http\Client\Response class.

So, now there is an error:
`Fatal error:  Declaration of DefStudio\Telegraph\Client\TelegraphResponse::dump(): static must be compatible with Illuminate\Http\Client\Response::dump($key = null)`

Laravel 11
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Http/Client/Response.php

Laravel 10
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Http/Client/Response.php

