### PR TITLE
Fixed a collision of custom command prefixes

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -129,7 +129,7 @@ abstract class WebhookHandler
                 Str::length($prefix)
             )->before(' ');
 
-            if ($cut->startsWith($prefixFirstLetters)) {
+            if ($cut->startsWith($commandPrefixes) || $cut->startsWith($prefixFirstLetters)) {
                 continue;
             }
 

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -419,15 +419,13 @@ abstract class WebhookHandler
 
         return collect($prefixes)
             ->push('/')
-            ->map(fn (string $prefix) => str($prefix)->trim()->toString())
+            ->map(fn (string $prefix) => str($prefix)->trim())
             ->unique();
     }
 
     protected function isCommand(Stringable $text, Collection $commandPrefixes): bool
     {
-        $prefixFirstLetters = $commandPrefixes->map(
-            fn (string $prefix) => Str::of($prefix)->trim()->substr(0, 1)->toString()
-        );
+        $prefixFirstLetters = $commandPrefixes->map->substr(0, 1);
 
         foreach ($commandPrefixes as $prefix) {
             if (!$text->startsWith($prefix)) {

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -114,25 +114,7 @@ abstract class WebhookHandler
 
         $text = Str::of($this->message?->text() ?? '');
 
-        $commandPrefixes = $this->commandPrefixes();
-
-        $prefixFirstLetters = $commandPrefixes->map(
-            fn (string $prefix) => Str::of($prefix)->trim()->substr(01)->toString()
-        );
-
-        foreach ($commandPrefixes as $prefix) {
-            if (!$text->startsWith($prefix)) {
-                continue;
-            }
-
-            $cut = $text->substr(
-                Str::length($prefix)
-            )->before(' ');
-
-            if ($cut->startsWith($commandPrefixes) || $cut->startsWith($prefixFirstLetters)) {
-                continue;
-            }
-
+        if ($this->isCommand($text, $this->commandPrefixes())) {
             $this->handleCommand($text);
 
             return;
@@ -439,6 +421,31 @@ abstract class WebhookHandler
             ->push('/')
             ->map(fn (string $prefix) => str($prefix)->trim()->toString())
             ->unique();
+    }
+
+    protected function isCommand(Stringable $text, Collection $commandPrefixes): bool
+    {
+        $prefixFirstLetters = $commandPrefixes->map(
+            fn (string $prefix) => Str::of($prefix)->trim()->substr(0, 1)->toString()
+        );
+
+        foreach ($commandPrefixes as $prefix) {
+            if (!$text->startsWith($prefix)) {
+                continue;
+            }
+
+            $cut = $text->substr(
+                Str::length($prefix)
+            )->before(' ');
+
+            if ($cut->startsWith($commandPrefixes) || $cut->startsWith($prefixFirstLetters)) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     protected function createChat(Chat $telegramChat, TelegraphChat $chat): void

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -114,12 +114,29 @@ abstract class WebhookHandler
 
         $text = Str::of($this->message?->text() ?? '');
 
-        if ($text->startsWith($this->commandPrefixes())) {
+        $commandPrefixes = $this->commandPrefixes();
+
+        $prefixFirstLetters = $commandPrefixes->map(
+            fn (string $prefix) => Str::of($prefix)->trim()->substr(01)->toString()
+        );
+
+        foreach ($commandPrefixes as $prefix) {
+            if (!$text->startsWith($prefix)) {
+                continue;
+            }
+
+            $cut = $text->substr(
+                Str::length($prefix)
+            )->before(' ');
+
+            if ($cut->startsWith($prefixFirstLetters)) {
+                continue;
+            }
+
             $this->handleCommand($text);
 
             return;
         }
-
 
         if ($this->message?->newChatMembers()->isNotEmpty()) {
             foreach ($this->message->newChatMembers() as $member) {

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -425,7 +425,7 @@ abstract class WebhookHandler
 
     protected function isCommand(Stringable $text, Collection $commandPrefixes): bool
     {
-        $prefixFirstLetters = $commandPrefixes->map->substr(0, 1);
+        $firstLetters = $commandPrefixes->map->substr(0, 1);
 
         foreach ($commandPrefixes as $prefix) {
             if (!$text->startsWith($prefix)) {
@@ -436,7 +436,7 @@ abstract class WebhookHandler
                 Str::length($prefix)
             )->before(' ');
 
-            if ($cut->startsWith($commandPrefixes) || $cut->startsWith($prefixFirstLetters)) {
+            if ($cut->startsWith($commandPrefixes) || $cut->startsWith($firstLetters)) {
                 continue;
             }
 

--- a/tests/Unit/Concerns/HasBotsAndChatsTest.php
+++ b/tests/Unit/Concerns/HasBotsAndChatsTest.php
@@ -212,7 +212,7 @@ test('photo is validated', function (string $fileName, bool $valid, string $exce
             'telegraph.attachments.photo.height_width_sum_px' => 799,
         ],
     ],
-])->only();
+]);
 
 it('can delete chat photo', function () {
     expect(function (\DefStudio\Telegraph\Telegraph $telegraph) {

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -265,6 +265,37 @@ it('cannot handle a command with custom start char', function () {
     Facade::assertNotSent("Hello!! your parameter is [foo bot 1]");
 });
 
+it('can handle a command with command collision', function () {
+    Config::set('telegraph.commands.start_with', ['-', '=', '!', ' % ', 1, ' :: ']);
+
+    $bot = bot();
+    Facade::fake();
+
+    app(TestWebhookHandler::class)->handle(webhook_command('--hello@bot foo bot -'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('==hello@bot foo bot ='), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('!!!!hello@bot foo bot !'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('%%%%%hello@bot foo bot %'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('1111hello@bot foo bot 1'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command(':::hello@bot foo bot :1'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command('::::hello@bot foo bot :2'), $bot);
+
+    Facade::assertNotSent("Hello!! your parameter is [foo bot -]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot =]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot !]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot %]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot 1]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot :1]");
+    Facade::assertNotSent("Hello!! your parameter is [foo bot :2]");
+
+    Facade::assertSent("Received: --hello@bot foo bot -");
+    Facade::assertSent("Received: ==hello@bot foo bot =");
+    Facade::assertSent("Received: !!!!hello@bot foo bot !");
+    Facade::assertSent("Received: %%%%%hello@bot foo bot %");
+    Facade::assertSent("Received: 1111hello@bot foo bot 1");
+    Facade::assertSent("Received: :::hello@bot foo bot :1");
+    Facade::assertSent("Received: ::::hello@bot foo bot :2");
+});
+
 it('can change the inline keyboard', function () {
     Config::set('telegraph.security.allow_callback_queries_from_unknown_chats', true);
     Config::set('telegraph.security.allow_messages_from_unknown_chats', true);

--- a/tests/Unit/Handlers/WebhookHandlerTest.php
+++ b/tests/Unit/Handlers/WebhookHandlerTest.php
@@ -245,7 +245,7 @@ it('can handle a command without parameter', function () {
     Facade::assertSent("Hello!!");
 });
 
-it('cannot handle a command with custom start char', function () {
+it('does not handle a command with custom start char', function () {
     $bot = bot();
     Facade::fake();
 
@@ -265,36 +265,26 @@ it('cannot handle a command with custom start char', function () {
     Facade::assertNotSent("Hello!! your parameter is [foo bot 1]");
 });
 
-it('can handle a command with command collision', function () {
+it('can handle a command with command collision', function (string $command, string $notSent, string $sent) {
     Config::set('telegraph.commands.start_with', ['-', '=', '!', ' % ', 1, ' :: ']);
 
     $bot = bot();
     Facade::fake();
 
-    app(TestWebhookHandler::class)->handle(webhook_command('--hello@bot foo bot -'), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command('==hello@bot foo bot ='), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command('!!!!hello@bot foo bot !'), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command('%%%%%hello@bot foo bot %'), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command('1111hello@bot foo bot 1'), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command(':::hello@bot foo bot :1'), $bot);
-    app(TestWebhookHandler::class)->handle(webhook_command('::::hello@bot foo bot :2'), $bot);
+    app(TestWebhookHandler::class)->handle(webhook_command($command), $bot);
 
-    Facade::assertNotSent("Hello!! your parameter is [foo bot -]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot =]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot !]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot %]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot 1]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot :1]");
-    Facade::assertNotSent("Hello!! your parameter is [foo bot :2]");
+    Facade::assertNotSent("Hello!! your parameter is [$notSent]");
 
-    Facade::assertSent("Received: --hello@bot foo bot -");
-    Facade::assertSent("Received: ==hello@bot foo bot =");
-    Facade::assertSent("Received: !!!!hello@bot foo bot !");
-    Facade::assertSent("Received: %%%%%hello@bot foo bot %");
-    Facade::assertSent("Received: 1111hello@bot foo bot 1");
-    Facade::assertSent("Received: :::hello@bot foo bot :1");
-    Facade::assertSent("Received: ::::hello@bot foo bot :2");
-});
+    Facade::assertSent("Received: $sent");
+})->with([
+    ['command' => '--hello@bot foo bot -', 'notSent' => 'foo bot -', 'sent' => '--hello@bot foo bot -'],
+    ['command' => '==hello@bot foo bot =', 'notSent' => 'foo bot =', 'sent' => '==hello@bot foo bot ='],
+    ['command' => '!!!!hello@bot foo bot !', 'notSent' => 'foo bot !', 'sent' => '!!!!hello@bot foo bot !'],
+    ['command' => '%%%%%hello@bot foo bot %', 'notSent' => 'foo bot %', 'sent' => '%%%%%hello@bot foo bot %'],
+    ['command' => '1111hello@bot foo bot 1', 'notSent' => 'foo bot 1', 'sent' => '1111hello@bot foo bot 1'],
+    ['command' => ':::hello@bot foo bot :1', 'notSent' => 'foo bot :1', 'sent' => ':::hello@bot foo bot :1'],
+    ['command' => '::::hello@bot foo bot :2', 'notSent' => 'foo bot :2', 'sent' => '::::hello@bot foo bot :2'],
+]);
 
 it('can change the inline keyboard', function () {
     Config::set('telegraph.security.allow_callback_queries_from_unknown_chats', true);


### PR DESCRIPTION
I'm surprised I haven't encountered this before.....

In general, over the last two days I've encountered a collision of custom commands, as a result of which a message is defined as a command.

For example:

```php
// config/telegraph.php
return [
    // ...
    'commands' => [
        'start_with' => ['/', '!'],
    ],
];
```
```json
{
    "message": {
        "chat": { "id": -111, "type": "supergroup", "title": "Test Group"},
        "date": 1727720853,
        "from": { "id": 333, "is_bot": false, "first_name": "John"},
        "text": "!!!Some message",
        "message_id": 1854
    },
    "update_id": 577874479
}
```

The current version of the Telegraph would define this as a command:

```php
dd([
    'command' => '!!Some',
    'parameter' => 'message',
]);
```

The proposed fix adds collision checking for commands, taking into account the fact that a command can start with any number of characters, e.g. `::` or `:::::::`.

It works like this: if the first character of any of the command prefixes is found after the command name prefix specified in the settings, then the text being checked is not a command.

For example:

```
// prefixes is [ '!', '::' ]

// it's a command `some` with `message` as context
!some message
::some message

// it's not a command
!!some message
:some message
:::some message
::::some message
==some message
```