### PR TITLE
feat: added support /command@bot

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -396,17 +396,19 @@ abstract class WebhookHandler
     protected function parseCommand(Stringable $text): array
     {
         $command = $text->before('@')->before(' ');
-
-        foreach ($this->commandPrefixes() as $prefix) {
-            if ($command->startsWith($prefix)) {
-                $parameter = $text->after($command)->after('@')->after(' ');
-                $command = $command->after($prefix);
-
-                break;
-            }
-        }
-
-        return [(string) $command, (string) ($parameter ?? '')];
+        
+		foreach (commandPrefixes() as $prefix) {
+			if ($command->startsWith($prefix)) {
+				$parameter = match (true) {
+					($text->after($command)->startsWith(' ')) => $text->after($command)->trim(),
+					default => null,
+				};
+				$command = $command->after($prefix);
+				break;
+			}
+		}
+        
+		return [(string) $command, (string) ($parameter ?? '')];
     }
 
     /**


### PR DESCRIPTION
Initially, when processing the command "/ban@botName", we had "botName" as a parameter, without @.

As I understand it, this was done due to the peculiarities of Telegram: /ban - all bots should react to this command
/ban@botName - and here only botName should react

This pr corrects this moment, as a result we get:
/ban@botName - [command: ban, parameter: (no) ]
/ban @botName - [command: ban, parameter: @botName (and earlier - "botName") ]