### PR TITLE
[Fix] Replace assert with explicit if check

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -138,7 +138,9 @@ abstract class WebhookHandler
             default => $this->callbackQuery?->message()?->chat(),
         };
 
-        assert($telegramChat !== null);
+        if ($telegramChat === null) {
+            return;
+        }
 
         $this->chat = $this->bot->chats()->firstOrNew([
             'chat_id' => $telegramChat->id(),
@@ -214,7 +216,9 @@ abstract class WebhookHandler
 
     protected function extractMessageData(): void
     {
-        assert($this->message !== null);
+        if ($this->message === null) {
+            return;
+        }
 
         $this->messageId = $this->message->id();
 
@@ -349,7 +353,9 @@ abstract class WebhookHandler
 
     protected function extractCallbackQueryData(): void
     {
-        assert($this->callbackQuery !== null);
+        if ($this->callbackQuery === null) {
+            return;
+        }
 
         $this->messageId = $this->callbackQuery->message()?->id() ?? throw TelegramWebhookException::invalidData('message id missing');
 
@@ -376,7 +382,9 @@ abstract class WebhookHandler
 
     protected function extractReactionData(): void
     {
-        assert($this->reaction !== null);
+        if ($this->reaction === null) {
+            return;
+        }
 
         $this->messageId = $this->reaction->id();
 


### PR DESCRIPTION
Reopen #707.

If the `zend.assertions` directive in is set to `-1` (which is recommended for production environments [example](https://github.com/php/php-src/blob/4122daa49421b0d079857d669b041e0f23f328ff/php.ini-production#L160)), then the statement `assert($telegramChat !== null);` is ignored. As a result, the method execution continues even when `$telegramChat` is `null`. This leads to the following error:

```
Call to a member function id() on null {"exception":"[object] (Error(code: 0): Call to a member function id() on null at /app/vendor/defstudio/telegraph/src/Handlers/WebhookHandler.php:144)
[stacktrace]
#0 /app/vendor/defstudio/telegraph/src/Handlers/WebhookHandler.php(103): DefStudio\\Telegraph\\Handlers\\WebhookHandler->setupChat()
#1 /app/vendor/defstudio/telegraph/src/Controllers/WebhookController.php(28): DefStudio\\Telegraph\\Handlers\\WebhookHandler->handle(Object(Illuminate\\Http\\Request), Object(App\\Models\\TelegraphBot))
```

To prevent this, the code should not rely solely on `assert()` for critical checks, especially since `zend.assertions` is disabled in production by setting it to `-1` in . `php.ini`.
