### PR TITLE
Fix: Edit channel post

### DIFF
--- a/src/DTO/TelegramUpdate.php
+++ b/src/DTO/TelegramUpdate.php
@@ -37,6 +37,7 @@ class TelegramUpdate implements Arrayable
      *     poll?:array<string, mixed>,
      *     poll_answer?:array<string, mixed>,
      *     channel_post?:array<string, mixed>,
+     *     edited_channel_post?:array<string, mixed>,
      *     callback_query?:array<string, mixed>,
      *     pre_checkout_query?:array<string, mixed>,
      *     my_chat_member?:array<string, mixed>,
@@ -71,6 +72,10 @@ class TelegramUpdate implements Arrayable
 
         if (isset($data['channel_post'])) {
             $update->message = Message::fromArray($data['channel_post']);
+        }
+
+        if (isset($data['edited_channel_post'])) {
+            $update->message = Message::fromArray($data['edited_channel_post']);
         }
 
         if (isset($data['callback_query'])) {

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -102,6 +102,7 @@ abstract class WebhookHandler
                 $this->request->has('message') => Message::fromArray($this->request->input('message')),
                 $this->request->has('edited_message') => Message::fromArray($this->request->input('edited_message')),
                 $this->request->has('channel_post') => Message::fromArray($this->request->input('channel_post')),
+                $this->request->has('edited_channel_post') => Message::fromArray($this->request->input('edited_channel_post')),
                 default => null,
             };
 

--- a/tests/Unit/DTO/TelegramUpdateTest.php
+++ b/tests/Unit/DTO/TelegramUpdateTest.php
@@ -103,8 +103,8 @@ it('export all properties to array', function () {
             'message_id' => 4,
             'date' => now()->timestamp,
             'text' => 'f',
-        ], 
-       'edited_channel_post' => [
+        ],
+        'edited_channel_post' => [
             'message_id' => 4,
             'date' => now()->timestamp,
             'edit_date' => now()->timestamp,

--- a/tests/Unit/DTO/TelegramUpdateTest.php
+++ b/tests/Unit/DTO/TelegramUpdateTest.php
@@ -16,6 +16,7 @@ it('export all properties to array', function () {
         'edited_message' => [
             'message_id' => 2,
             'date' => now()->timestamp,
+            'edit_date' => now()->timestamp,
             'text' => 'f',
         ],
         'message_reaction' => [
@@ -101,6 +102,12 @@ it('export all properties to array', function () {
         'channel_post' => [
             'message_id' => 4,
             'date' => now()->timestamp,
+            'text' => 'f',
+        ], 
+       'edited_channel_post' => [
+            'message_id' => 4,
+            'date' => now()->timestamp,
+            'edit_date' => now()->timestamp,
             'text' => 'f',
         ],
         'callback_query' => [


### PR DESCRIPTION
set edited_channel_post data like as channel_post data.
edited_channel_post only has an extra attribute called edit_date.