### PR TITLE
Fix: Chats for Handler

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -44,12 +44,12 @@ abstract class WebhookHandler
     protected int $callbackQueryId;
 
     protected Request $request;
-    protected Message|null $message = null;
-    protected Reaction|null $reaction = null;
-    protected ChatMemberUpdate|null $chatMember = null;
-    protected ChatMemberUpdate|null $myChatMember = null;
-    protected CallbackQuery|null $callbackQuery = null;
-    protected ChatJoinRequest|null $chatJoinRequest = null;
+    protected ?Message $message = null;
+    protected ?Reaction $reaction = null;
+    protected ?CallbackQuery $callbackQuery = null;
+    protected ?ChatJoinRequest $chatJoinRequest = null;
+    protected ?ChatMemberUpdate $myChatMember = null;
+    protected ?ChatMemberUpdate $chatMember = null;
 
     /**
      * @var Collection<string, string>|Collection<int, array<string, string>>|Collection<array-key, ReactionType>
@@ -86,37 +86,13 @@ abstract class WebhookHandler
             }
 
             if ($this->request->has('poll_answer')) {
-                $pollAnswer = PollAnswer::fromArray($this->request->input('poll_answer'));
-
-                $this->setupChat($pollAnswer->voterChat());
-
-                $this->handlePollAnswer($pollAnswer);
+                $this->handlePollAnswer(PollAnswer::fromArray($this->request->input('poll_answer')));
 
                 return;
             }
 
             if ($this->request->has('pre_checkout_query')) {
                 $this->handlePreCheckoutQuery(PreCheckoutQuery::fromArray($this->request->input('pre_checkout_query')));
-
-                return;
-            }
-
-            if ($this->request->has('chat_member')) {
-                $this->chatMember = ChatMemberUpdate::fromArray($this->request->input('chat_member'));
-
-                $this->setupChat();
-
-                $this->handleChatMemberUpdate($this->chatMember);
-
-                return;
-            }
-
-            if ($this->request->has('my_chat_member')) {
-                $this->myChatMember = ChatMemberUpdate::fromArray($this->request->input('my_chat_member'));
-
-                $this->setupChat();
-
-                $this->handleBotChatStatusUpdate($this->myChatMember);
 
                 return;
             }
@@ -145,6 +121,16 @@ abstract class WebhookHandler
                 default => null,
             };
 
+            $this->myChatMember = match (true) {
+                $this->request->has('my_chat_member') => ChatMemberUpdate::fromArray($this->request->input('my_chat_member')),
+                default => null,
+            };
+
+            $this->chatMember = match (true) {
+                $this->request->has('chat_member') => ChatMemberUpdate::fromArray($this->request->input('chat_member')),
+                default => null,
+            };
+
             // setup chat
             $this->setupChat();
 
@@ -153,9 +139,11 @@ abstract class WebhookHandler
                 isset($this->message) && $this->message->successfulPayment() => $this->handleSuccessfulPayment($this->message->successfulPayment()),
                 isset($this->message) && $this->message->migrateToChatId() => $this->handleMigrateToChat(),
                 isset($this->message) => $this->handleMessage(),
+                isset($this->reaction) => $this->handleReaction(),
                 isset($this->callbackQuery) => $this->handleCallbackQuery(),
                 isset($this->chatJoinRequest) => $this->handleChatJoinRequest($this->chatJoinRequest),
-                isset($this->reaction) => $this->handleReaction(),
+                isset($this->myChatMember) => $this->handleBotChatStatusUpdate($this->myChatMember),
+                isset($this->chatMember) => $this->handleChatMemberUpdate($this->chatMember),
                 default => null,
             };
         } catch (Throwable $throwable) {
@@ -171,19 +159,20 @@ abstract class WebhookHandler
 
         report($throwable);
 
-        rescue(fn () => $this->reply(__('telegraph::errors.webhook_error_occurred')), report: false);
+        rescue(fn() => $this->reply(__('telegraph::errors.webhook_error_occurred')), report: false);
     }
 
     //---- Chat Setup
     protected function setupChat(): void
     {
         $telegramChat = match (true) {
-            isset($this->chatMember) => $this->chatMember->chat(),
-            isset($this->myChatMember) => $this->myChatMember->chat(),
             isset($this->message) => $this->message->chat(),
             isset($this->reaction) => $this->reaction->chat(),
+            isset($this->callbackQuery) => $this->callbackQuery->message()?->chat(),
             isset($this->chatJoinRequest) => $this->chatJoinRequest->chat(),
-            default => $this->callbackQuery?->message()?->chat(),
+            isset($this->myChatMember) => $this->myChatMember->chat(),
+            isset($this->chatMember) => $this->chatMember->chat(),
+            default => null,
         };
 
         assert($telegramChat !== null);
@@ -304,7 +293,7 @@ abstract class WebhookHandler
 
         return collect($prefixes)
             ->push('/')
-            ->map(fn (string $prefix) => str($prefix)->trim())
+            ->map(fn(string $prefix) => str($prefix)->trim())
             ->unique()
             ->values();
     }


### PR DESCRIPTION
Hi @fabio-ivona.
I saw that there are several releases without changes. I checked and saw that you made changes in chat_member and my_chat_member.
That was really nice.
I suggested making some changes so that it follows the structure.

Actually, for poll_answer, I didn't understand why you put the voterChat() input in the setupChat method. That method has no input at all.
I wanted to implement it with setupchat() like the others. But I checked that voterChat doesn't always exist, so I reverted it to the previous state.