### PR TITLE
Feat: Can send custom endpoint request

### DIFF
--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \DefStudio\Telegraph\Telegraph  bot(TelegraphBot|string $bot)
  * @method static \DefStudio\Telegraph\Telegraph  chat(TelegraphChat|string $chat)
  * @method static \DefStudio\Telegraph\Telegraph  message(string $message)
+ * @method static \DefStudio\Telegraph\Telegraph  withEndpoint(string $endpoint)
  * @method static \DefStudio\Telegraph\Telegraph  withData(string $key, mixed $value)
  * @method static \DefStudio\Telegraph\Telegraph  inThread(int $thread_id)
  * @method static \DefStudio\Telegraph\Telegraph  html(string $message)

--- a/src/Models/TelegraphBot.php
+++ b/src/Models/TelegraphBot.php
@@ -96,6 +96,16 @@ class TelegraphBot extends Model implements Storable
         return $this->hasMany(config('telegraph.models.chat'), 'telegraph_bot_id');
     }
 
+    public function withEndpoint(string $endpoint): Telegraph
+    {
+        return TelegraphFacade::bot($this)->withEndpoint($endpoint);
+    }
+
+    public function withData(string $key, mixed $value): Telegraph
+    {
+        return TelegraphFacade::bot($this)->withData($key, $value);
+    }
+
     public function registerWebhook(bool|null $dropPendingUpdates = null, int|null $maxConnections = null, string|null $secretToken = null): Telegraph
     {
         return TelegraphFacade::bot($this)->registerWebhook($dropPendingUpdates, $maxConnections, $secretToken);

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -120,6 +120,11 @@ class TelegraphChat extends Model implements Storable
         return ChatMember::fromArray($reply->json('result'));
     }
 
+    public function withEndpoint(string $endpoint): Telegraph
+    {
+        return TelegraphFacade::chat($this)->withEndpoint($endpoint);
+    }
+
     public function withData(string $key, mixed $value): Telegraph
     {
         return TelegraphFacade::chat($this)->withData($key, $value);

--- a/src/Telegraph.php
+++ b/src/Telegraph.php
@@ -163,6 +163,15 @@ class Telegraph
         return $this;
     }
 
+    public function withEndpoint(string $endpoint): static
+    {
+        $telegraph = clone $this;
+
+        $telegraph->endpoint = ltrim($endpoint, '/');
+
+        return $telegraph;
+    }
+
     public function withData(string $key, mixed $value): static
     {
         $telegraph = clone $this;

--- a/tests/Unit/Models/TelegraphBotTest.php
+++ b/tests/Unit/Models/TelegraphBotTest.php
@@ -35,6 +35,19 @@ it('can retrieve its url', function () {
     expect($bot->url())->toMatchSnapshot();
 });
 
+it('can send request with custom endpoint and data', function () {
+    withfakeUrl();
+
+    Telegraph::fake();
+    $bot = make_bot();
+
+    $bot->withEndpoint('custom-endpoint')->withData('sample', 'test')->send();
+
+    Telegraph::assertSentData('custom-endpoint', [
+        'sample' => 'test',
+    ]);
+});
+
 it('can register its webhook', function () {
     withfakeUrl();
 

--- a/tests/Unit/Models/TelegraphChatTest.php
+++ b/tests/Unit/Models/TelegraphChatTest.php
@@ -806,6 +806,17 @@ it('can set web app menu button', function () {
     ]);
 });
 
+it('can send request with custom endpoint and data', function () {
+    Telegraph::fake();
+    $chat = make_chat();
+
+    $chat->withEndpoint('custom-endpoint')->withData('sample', 'test')->send();
+
+    Telegraph::assertSentData('custom-endpoint', [
+        'sample' => 'test',
+    ]);
+});
+
 it('can edit Telegraph data before sending a media ', function () {
     Telegraph::fake();
     $chat = make_chat();


### PR DESCRIPTION
I implemented a new method called `withEndpoint()` so that we can set custom endpoints.

Why?
- We can quickly implement methods that are not implemented, without having to contribute.
- I use this package for another messenger (for our country), and it almost follows the structure of Telegram. It has a few different methods from Telegram, and this is how I can use them.