### PR TITLE
Allow deferred bot/chat assignment for composed messages

### DIFF
--- a/src/Concerns/ComposesMessages.php
+++ b/src/Concerns/ComposesMessages.php
@@ -25,7 +25,7 @@ trait ComposesMessages
         $this->endpoint ??= self::ENDPOINT_MESSAGE;
 
         $this->data['text'] = $message;
-        $this->data['chat_id'] = $this->getChatId();
+        $this->syncChatIdData();
     }
 
     public function html(?string $message = null): Telegraph
@@ -119,9 +119,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -135,9 +136,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_MESSAGES;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_ids' => $messageIds,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -148,9 +150,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_READ_BUSINESS_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -164,9 +167,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_BUSINESS_MESSAGES;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_ids' => $messageIds,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -177,9 +181,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_PIN_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -190,9 +195,10 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_UNPIN_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -202,9 +208,8 @@ trait ComposesMessages
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_UNPIN_ALL_MESSAGES;
-        $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
-        ];
+        $telegraph->data = ['chat_id' => null];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -217,10 +222,11 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_FORWARD_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
             'from_chat_id' => $fromChatId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -233,10 +239,11 @@ trait ComposesMessages
 
         $telegraph->endpoint = self::ENDPOINT_COPY_MESSAGE;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
             'from_chat_id' => $fromChatId,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }

--- a/src/Concerns/HasBotsAndChats.php
+++ b/src/Concerns/HasBotsAndChats.php
@@ -118,12 +118,113 @@ trait HasBotsAndChats
         return $chat;
     }
 
+    protected function syncChatIdData(): void
+    {
+        $chat = $this->getChatIfAvailable();
+
+        if ($chat === null) {
+            return;
+        }
+
+        $this->data['chat_id'] = $chat instanceof TelegraphChat
+            ? $chat->chat_id
+            : $chat;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function prepareChatData(array $data): array
+    {
+        $chat = $this->getChatIfAvailable();
+        $shouldSetChatId = array_key_exists('chat_id', $data) || $this->endpointRequiresChat();
+
+        if ($chat !== null && $shouldSetChatId) {
+            $data['chat_id'] = $chat instanceof TelegraphChat
+                ? $chat->chat_id
+                : $chat;
+
+            return $data;
+        }
+
+        if ($this->endpointRequiresChat() && !array_key_exists('chat_id', $data)) {
+            throw TelegraphException::missingChat();
+        }
+
+        return $data;
+    }
+
+    protected function endpointRequiresChat(): bool
+    {
+        return in_array($this->endpoint ?? null, [
+            self::ENDPOINT_REPLACE_KEYBOARD,
+            self::ENDPOINT_MESSAGE,
+            self::ENDPOINT_DELETE_MESSAGE,
+            self::ENDPOINT_DELETE_MESSAGES,
+            self::ENDPOINT_READ_BUSINESS_MESSAGE,
+            self::ENDPOINT_DELETE_BUSINESS_MESSAGES,
+            self::ENDPOINT_PIN_MESSAGE,
+            self::ENDPOINT_UNPIN_MESSAGE,
+            self::ENDPOINT_UNPIN_ALL_MESSAGES,
+            self::ENDPOINT_EDIT_MESSAGE,
+            self::ENDPOINT_EDIT_CAPTION,
+            self::ENDPOINT_EDIT_MEDIA,
+            self::ENDPOINT_SEND_LOCATION,
+            self::ENDPOINT_SEND_ANIMATION,
+            self::ENDPOINT_SEND_VOICE,
+            self::ENDPOINT_SEND_MEDIA_GROUP,
+            self::ENDPOINT_SEND_CHAT_ACTION,
+            self::ENDPOINT_SEND_DOCUMENT,
+            self::ENDPOINT_SEND_PHOTO,
+            self::ENDPOINT_SEND_VIDEO,
+            self::ENDPOINT_SEND_VIDEO_NOTE,
+            self::ENDPOINT_SEND_AUDIO,
+            self::ENDPOINT_SEND_CONTACT,
+            self::ENDPOINT_SET_CHAT_TITLE,
+            self::ENDPOINT_SET_CHAT_DESCRIPTION,
+            self::ENDPOINT_SET_CHAT_PHOTO,
+            self::ENDPOINT_SET_MESSAGE_REACTION,
+            self::ENDPOINT_DELETE_CHAT_PHOTO,
+            self::ENDPOINT_EXPORT_CHAT_INVITE_LINK,
+            self::ENDPOINT_CREATE_CHAT_INVITE_LINK,
+            self::ENDPOINT_CREATE_FORUM_TOPIC,
+            self::ENDPOINT_EDIT_FORUM_TOPIC,
+            self::ENDPOINT_CLOSE_FORUM_TOPIC,
+            self::ENDPOINT_REOPEN_FORUM_TOPIC,
+            self::ENDPOINT_DELETE_FORUM_TOPIC,
+            self::ENDPOINT_EDIT_CHAT_INVITE_LINK,
+            self::ENDPOINT_REVOKE_CHAT_INVITE_LINK,
+            self::ENDPOINT_LEAVE_CHAT,
+            self::ENDPOINT_GET_CHAT_INFO,
+            self::ENDPOINT_GET_CHAT_MEMBER_COUNT,
+            self::ENDPOINT_GET_CHAT_MEMBER,
+            self::ENDPOINT_GET_CHAT_ADMINISTRATORS,
+            self::ENDPOINT_SET_CHAT_PERMISSIONS,
+            self::ENDPOINT_BAN_CHAT_MEMBER,
+            self::ENDPOINT_UNBAN_CHAT_MEMBER,
+            self::ENDPOINT_RESTRICT_CHAT_MEMBER,
+            self::ENDPOINT_PROMOTE_CHAT_MEMBER,
+            self::ENDPOINT_SEND_POLL,
+            self::ENDPOINT_FORWARD_MESSAGE,
+            self::ENDPOINT_COPY_MESSAGE,
+            self::ENDPOINT_DICE,
+            self::ENDPOINT_SEND_STICKER,
+            self::ENDPOINT_SEND_VENUE,
+            self::ENDPOINT_APPROVE_CHAT_JOIN_REQUEST,
+            self::ENDPOINT_DECLINE_CHAT_JOIN_REQUEST,
+            self::ENDPOINT_SEND_INVOICE,
+            self::ENDPOINT_SEND_GAME,
+        ], true);
+    }
+
     public function leaveChat(): Telegraph
     {
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_LEAVE_CHAT;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -132,7 +233,7 @@ trait HasBotsAndChats
     {
         $telegraph = clone $this;
         $telegraph->endpoint = self::ENDPOINT_CREATE_FORUM_TOPIC;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['name'] = $name;
 
         if ($iconColor !== null) {
@@ -155,7 +256,7 @@ trait HasBotsAndChats
         }
 
         $telegraph->endpoint = self::ENDPOINT_EDIT_FORUM_TOPIC;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         if ($threadId !== null) {
             $telegraph->data['message_thread_id'] = $threadId;
@@ -180,7 +281,7 @@ trait HasBotsAndChats
             throw ChatThreadException::emptyThreadId();
         }
         $telegraph->endpoint = self::ENDPOINT_CLOSE_FORUM_TOPIC;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         if ($threadId !== null) {
             $telegraph->data['message_thread_id'] = $threadId;
@@ -197,7 +298,7 @@ trait HasBotsAndChats
             throw ChatThreadException::emptyThreadId();
         }
         $telegraph->endpoint = self::ENDPOINT_REOPEN_FORUM_TOPIC;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         if ($threadId !== null) {
             $telegraph->data['message_thread_id'] = $threadId;
@@ -214,7 +315,7 @@ trait HasBotsAndChats
             throw ChatThreadException::emptyThreadId();
         }
         $telegraph->endpoint = self::ENDPOINT_DELETE_FORUM_TOPIC;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         if ($threadId !== null) {
             $telegraph->data['message_thread_id'] = $threadId;
@@ -267,7 +368,7 @@ trait HasBotsAndChats
         in_array($action, ChatActions::available_actions()) || throw TelegraphException::invalidChatAction($action);
 
         $telegraph->endpoint = self::ENDPOINT_SEND_CHAT_ACTION;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['action'] = $action;
 
         return $telegraph;
@@ -281,7 +382,7 @@ trait HasBotsAndChats
         strlen($title) < 256 || throw ChatSettingsException::titleMaxLengthExceeded();
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_TITLE;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['title'] = $title;
 
         return $telegraph;
@@ -294,7 +395,7 @@ trait HasBotsAndChats
         strlen($description) < 256 || throw ChatSettingsException::descriptionMaxLengthExceeded();
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_DESCRIPTION;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['description'] = $description;
 
         return $telegraph;
@@ -305,7 +406,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_PHOTO;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         File::exists($path) || throw FileException::fileNotFound('photo', $path);
 
@@ -352,7 +453,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_MESSAGE_REACTION;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['message_id'] = $messageId;
         $telegraph->data['reaction'] = json_encode([$reaction]);
         $telegraph->data['is_big'] = $isBig;
@@ -375,7 +476,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_DELETE_CHAT_PHOTO;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -385,7 +486,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_INFO;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -396,7 +497,7 @@ trait HasBotsAndChats
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_MENU_BUTTON;
 
         if ($this->getChatIfAvailable() !== null) {
-            $telegraph->data['chat_id'] = $this->getChatId();
+            $telegraph->syncChatIdData();
         }
 
 
@@ -417,7 +518,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_EXPORT_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -427,7 +528,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_CREATE_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -473,7 +574,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_EDIT_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['invite_link'] = $link;
 
         return $telegraph;
@@ -484,7 +585,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_REVOKE_CHAT_INVITE_LINK;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['invite_link'] = $link;
 
         return $telegraph;
@@ -495,7 +596,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_MEMBER_COUNT;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -505,7 +606,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;
@@ -516,7 +617,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_GET_CHAT_ADMINISTRATORS;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }
@@ -529,7 +630,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SET_CHAT_PERMISSIONS;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
 
         $permissions = collect($permissions)
             ->mapWithKeys(
@@ -548,7 +649,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_BAN_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;
@@ -577,7 +678,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_UNBAN_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
         $telegraph->data['only_if_banned'] = $onlyIfBanned;
 
@@ -592,7 +693,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_RESTRICT_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         /** @var array<string, bool> $permissions */
@@ -617,7 +718,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_PROMOTE_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         /** @var array<string, bool> $permissions */
@@ -640,7 +741,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_PROMOTE_CHAT_MEMBER;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         /** @var array<string|bool> $permissions */
@@ -661,7 +762,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_APPROVE_CHAT_JOIN_REQUEST;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;
@@ -672,7 +773,7 @@ trait HasBotsAndChats
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_DECLINE_CHAT_JOIN_REQUEST;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['user_id'] = $userId;
 
         return $telegraph;

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -64,6 +64,7 @@ trait InteractsWithTelegram
         $data = $this->data;
 
         $data = $this->pipeTraits('preprocessData', $data);
+        $data = $this->prepareChatData($data);
 
         if ($asMultipart) {
             $data = collect($data)
@@ -129,6 +130,7 @@ trait InteractsWithTelegram
     public function getUrl(): string
     {
         $bot = $this->getBot();
+        $data = $this->prepareData();
 
         $url = $bot instanceof HasCustomUrl
             ? $bot->getUrl()
@@ -139,7 +141,7 @@ trait InteractsWithTelegram
         /** @phpstan-ignore-next-line */
         return Str::of($url)
             ->append('/', $this->endpoint)
-            ->when(!empty($this->data), fn (Stringable $str) => $str->append('?', http_build_query($this->data)))
+            ->when(!empty($data), fn (Stringable $str) => $str->append('?', http_build_query($data)))
             ->toString();
     }
 

--- a/src/Concerns/ManagesKeyboards.php
+++ b/src/Concerns/ManagesKeyboards.php
@@ -116,10 +116,11 @@ trait ManagesKeyboards
 
         $telegraph->endpoint = self::ENDPOINT_REPLACE_KEYBOARD;
         $telegraph->data = [
-            'chat_id' => $telegraph->getChatId(),
+            'chat_id' => null,
             'message_id' => $messageId,
             'reply_markup' => $replyMarkup,
         ];
+        $telegraph->syncChatIdData();
 
         return $telegraph;
     }

--- a/src/ScopedPayloads/TelegraphPollPayload.php
+++ b/src/ScopedPayloads/TelegraphPollPayload.php
@@ -18,7 +18,7 @@ class TelegraphPollPayload extends Telegraph
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SEND_POLL;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['options'] = [];
         $telegraph->data['question'] = $question;
 

--- a/src/ScopedPayloads/TelegraphQuizPayload.php
+++ b/src/ScopedPayloads/TelegraphQuizPayload.php
@@ -21,7 +21,7 @@ class TelegraphQuizPayload extends Telegraph
         $telegraph = clone $this;
 
         $telegraph->endpoint = self::ENDPOINT_SEND_POLL;
-        $telegraph->data['chat_id'] = $telegraph->getChatId();
+        $telegraph->syncChatIdData();
         $telegraph->data['type'] = 'quiz';
         $telegraph->data['options'] = [];
         $telegraph->data['question'] = $question;

--- a/src/Support/Testing/Fakes/TelegraphFake.php
+++ b/src/Support/Testing/Fakes/TelegraphFake.php
@@ -36,9 +36,20 @@ class TelegraphFake extends Telegraph
         $this->files = new Collection();
     }
 
+    protected function inheritState(Telegraph $fake): Telegraph
+    {
+        $fake->bot = $this->bot;
+        $fake->chat = $this->chat;
+        $fake->data = $this->data;
+        $fake->baseUrl = $this->baseUrl;
+        $fake->httpProxy = $this->httpProxy;
+
+        return $fake;
+    }
+
     public function editMedia(int $messageId): TelegraphEditMediaFake
     {
-        $fake = new TelegraphEditMediaFake($this->replies);
+        $fake = $this->inheritState(new TelegraphEditMediaFake($this->replies));
         $fake->endpoint = self::ENDPOINT_EDIT_MEDIA;
         $fake->data['message_id'] = $messageId;
 
@@ -47,7 +58,7 @@ class TelegraphFake extends Telegraph
 
     public function poll(string $question): TelegraphPollPayload
     {
-        $fake = new TelegraphPollFake($this->replies);
+        $fake = $this->inheritState(new TelegraphPollFake($this->replies));
         $fake->endpoint = self::ENDPOINT_SEND_POLL;
         $fake->data['options'] = [];
         $fake->data['question'] = $question;
@@ -57,16 +68,15 @@ class TelegraphFake extends Telegraph
 
     public function setChatMenuButton(): SetChatMenuButtonPayload
     {
-        $fake = new TelegraphSetChatMenuButtonFake($this->replies);
+        $fake = $this->inheritState(new TelegraphSetChatMenuButtonFake($this->replies));
         $fake->endpoint = self::ENDPOINT_SET_CHAT_MENU_BUTTON;
-        $fake->data = $this->data;
 
         return $fake;
     }
 
     public function quiz(string $question): TelegraphQuizPayload
     {
-        $fake = new TelegraphQuizFake($this->replies);
+        $fake = $this->inheritState(new TelegraphQuizFake($this->replies));
         $fake->endpoint = self::ENDPOINT_SEND_POLL;
         $fake->data['options'] = [];
         $fake->data['question'] = $question;

--- a/tests/Unit/Concerns/ComposesMessagesTest.php
+++ b/tests/Unit/Concerns/ComposesMessagesTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use DefStudio\Telegraph\Exceptions\TelegraphException;
+use DefStudio\Telegraph\Facades\Telegraph as Facade;
+use DefStudio\Telegraph\Keyboard\Keyboard;
 use DefStudio\Telegraph\Telegraph;
 
 it('can send an html message', function () {
@@ -88,4 +91,32 @@ it('can delete business messages', function () {
 
     expect(fn (Telegraph $telegraph) => $telegraph->deleteBusinessMessages([123])->inBusiness(321))
         ->toMatchTelegramSnapshot();
+});
+
+it('can defer bot and chat assignment for a composed message', function () {
+    Facade::fake();
+
+    $chat = make_chat();
+
+    Facade::html('foobar')
+        ->keyboard(Keyboard::make())
+        ->withoutPreview()
+        ->bot($chat->bot)
+        ->chat($chat)
+        ->send();
+
+    Facade::assertSentData(Telegraph::ENDPOINT_MESSAGE, [
+        'chat_id' => $chat->chat_id,
+        'text' => 'foobar',
+        'parse_mode' => Telegraph::PARSE_HTML,
+        'disable_web_page_preview' => true,
+    ], false);
+});
+
+it('throws missing chat only when sending a deferred message', function () {
+    expect(fn () => app(Telegraph::class)->html('foobar'))
+        ->not->toThrow(TelegraphException::class);
+
+    expect(fn () => app(Telegraph::class)->html('foobar')->bot('test-token')->send())
+        ->toThrow(TelegraphException::class, 'No TelegraphChat defined for this request');
 });


### PR DESCRIPTION


**Summary**
This PR makes `Telegraph` message composition more flexible by allowing a message to be built before a bot and chat are assigned.

Previously, calling builders like `Telegraph::html(...)` immediately tried to resolve `chat_id`, which made it impossible to compose a reusable message in one service and decide the destination bot/chat later in another service.

With this change, message builders can now create a `Telegraph` payload without an attached chat, and the required `chat_id` is resolved only when the request is finalized and sent.

**Problem**
A common use case is to build the same message once and send it to multiple recipients:

```php
$message = Telegraph::html(implode(PHP_EOL, $lines))
    ->keyboard(...)
    ->withoutPreview();

$message->bot($botA)->chat($chatA)->send();
$message->bot($botB)->chat($chatB)->send();
```

Before this PR, this failed at composition time because `html()` called `setMessageText()`, which immediately tried to populate `chat_id` and threw:

`No TelegraphChat defined for this request`

That made reusable message composition impossible unless the builder already knew the destination chat.

**What changed**
- Deferred `chat_id` resolution for composed text messages.
- Added centralized chat payload preparation before request execution.
- Kept validation strict at send time: requests that actually require a chat still fail if no chat is defined when sending.
- Preserved existing eager behavior for attachments and other APIs that already rely on immediate chat resolution.
- Preserved existing payload ordering where needed to avoid breaking snapshot tests.
- Fixed fake/scoped payload behavior so `poll`, `quiz`, and `editMedia` fakes inherit bot/chat state correctly.

**Behavior after this PR**
This now works:

```php
$message = Telegraph::html('Hello')
    ->keyboard(...)
    ->withoutPreview();

$message->bot($channel->bot)->chat($channel->chat_id)->send();
```

And it still correctly fails if a chat is still missing at send time for endpoints that require it.

**Implementation notes**
- Introduced deferred chat synchronization in the request preparation flow.
- Restricted “chat required” validation to a defined set of endpoints instead of applying it too broadly.
- Restored eager `missingChat` behavior for attachments to avoid changing existing API contracts.
- Updated tests to cover deferred composition and send-time validation.

**Result**
This enables a cleaner separation of responsibilities:
- one service can build a reusable Telegram message;
- another service can decide which bot/chat should receive it.
