### PR TITLE
docs: document queue processing best practices

### DIFF
--- a/docs/12.features/5.queued-messages.md
+++ b/docs/12.features/5.queued-messages.md
@@ -3,12 +3,121 @@ title: 'Queued Messages'
 navigation.title: 'Queued Messages'
 ---
 
-A `->dispatch()` method can be used to have Telegraph to interact with telegraph through the Laravel queue system:
+Telegraph can send a Telegram API request immediately or hand it to Laravel's queue system.
 
+This page covers outbound requests from your application to Telegram. For heavy work triggered by incoming updates, see [Background Webhook Processing](../15.webhooks/10.background-processing).
+
+## Send immediately
+
+`send()` performs the HTTP request during the current process and returns its response:
+
+```php
+$response = Telegraph::message('hello')->send();
+```
+
+This is useful when the caller needs the Telegram response before it can continue. The caller also waits for the network request to finish.
+
+## Dispatch through Laravel queues
+
+`dispatch()` creates a queued job for the outbound Telegram API request:
 
 ```php
 Telegraph::message('hello')->dispatch();
 ```
 
+Without an argument, Laravel uses the default queue configured for the application's default queue connection. Make sure the host application uses an asynchronous queue driver and runs queue workers. With the `sync` driver, the job still runs in the current process.
 
-optionally a queue name can be hinted: `->dispatch('my queue')`
+Pass a queue name to route the request to a specific queue:
+
+```php
+Telegraph::message('Your export is ready')
+    ->dispatch('telegram-interactive');
+```
+
+The queue belongs to the host Laravel application. Telegraph does not configure the queue connection, start workers, or require a particular queue driver.
+
+## Use a fixed set of queues
+
+For bots that serve interactive traffic and send bulk notifications, use a small, fixed set of queues:
+
+```php
+// Replies and other user-facing responses.
+Telegraph::message('Done')
+    ->dispatch('telegram-interactive');
+
+// Scheduled or bulk notifications.
+Telegraph::message('Weekly summary')
+    ->dispatch('telegram-broadcasts');
+```
+
+Avoid creating a queue name for every bot, chat, or user. Workers consume explicitly configured queue names, so dynamic names make worker configuration, capacity planning, and monitoring harder.
+
+Queue names separate workloads; they do not apply Telegram rate limits. They also do not guarantee that requests for the same chat will be processed in order when multiple workers are active. If ordering matters, the host application must coordinate it explicitly.
+
+## Allocate worker capacity
+
+Running more than one worker lets Laravel process queued requests concurrently. To ensure broadcasts cannot consume all available workers, reserve capacity with separate worker pools:
+
+```shell
+php artisan queue:work --queue=telegram-interactive
+```
+
+```shell
+php artisan queue:work --queue=telegram-broadcasts
+```
+
+Run the required number of each process under Supervisor, systemd, a container orchestrator, or another process monitor. Scale the interactive pool for response latency and the broadcasts pool for throughput.
+
+A single worker can listen to both queues in priority order:
+
+```shell
+php artisan queue:work --queue=telegram-interactive,telegram-broadcasts
+```
+
+Laravel checks `telegram-interactive` first in this configuration. This is useful for simple deployments, but it does not reserve worker capacity for broadcasts and a continuously busy interactive queue can delay them.
+
+See the official [Laravel queue documentation](https://laravel.com/docs/13.x/queues) for queue connections, workers, process monitors, and failed jobs.
+
+## Optional Horizon setup
+
+[Laravel Horizon](https://laravel.com/docs/13.x/horizon) is an optional dashboard and worker configuration system for Redis queues. It is configured by the host application and is not a Telegraph dependency.
+
+When each workload needs reserved capacity, define separate Horizon supervisors instead of relying on one auto-balanced supervisor:
+
+```php
+'environments' => [
+    'production' => [
+        'telegram-interactive' => [
+            'connection' => 'redis',
+            'queue' => ['telegram-interactive'],
+            'balance' => 'auto',
+            'minProcesses' => 2,
+            'maxProcesses' => 4,
+        ],
+
+        'telegram-broadcasts' => [
+            'connection' => 'redis',
+            'queue' => ['telegram-broadcasts'],
+            'balance' => 'auto',
+            'minProcesses' => 1,
+            'maxProcesses' => 2,
+        ],
+    ],
+],
+```
+
+Each supervisor reserves its own minimum capacity and scales only within its maximum. Choose process counts from observed load and infrastructure limits. Horizon's auto balancing reallocates workers according to queue load; it does not enforce Telegram rate limits or strict priority between queues.
+
+## Telegram limits and 429 responses
+
+Worker concurrency controls how quickly your application starts requests; it is not a Telegram API rate limiter. Telegram's current [broadcasting guidance](https://core.telegram.org/bots/faq#broadcasting-to-users) recommends avoiding more than one message per second in a single chat, limits groups to 20 messages per minute, and describes roughly 30 messages per second for free bulk broadcasts. Treat these as Telegram guidance, not guarantees made by Telegraph.
+
+When flood control is exceeded, Telegram may return HTTP 429. Its [Bot API `ResponseParameters`](https://core.telegram.org/bots/api#responseparameters) can include `retry_after`, the number of seconds to wait before repeating the request.
+
+The current Telegraph queued request job performs one HTTP request. It does not inspect a 429 response or automatically release and retry the job using `retry_after`. If the application sends enough traffic to require throttling or retries, implement those controls in the host application and make repeated operations idempotent.
+
+## Operational checks
+
+Monitor queue depth, queue wait time, and failed-job count for each fixed queue. These metrics reveal head-of-line blocking without recording Telegram request payloads.
+
+Do not include bot tokens, full Telegram API URLs, message content, or chat and user identifiers in shared queue logs or dashboards.

--- a/docs/15.webhooks/1.overview.md
+++ b/docs/15.webhooks/1.overview.md
@@ -7,6 +7,8 @@ Telegram bots can interact with chats and users through a webhook system that en
 
 For public `https` URL setup, local tunnels, secret tokens, and checks with `telegraph:debug-webhook`, see [Register Webhooks](2.registering-webhooks). For first-bot setup diagnostics, see [Troubleshooting Telegraph onboarding](../11.quickstart/7.troubleshooting).
 
+Webhook handlers run synchronously by default. For production queue boundaries, short callback handlers, and application-owned background jobs, see [Background Webhook Processing](10.background-processing).
+
 > [!WARNING]
 > By default webhooks can handle incoming requests from "known" chats (the one stored in database as TelegraphChat models) and will reject all others. In order to handle unknown chats see [below](#handle-requests-from-unknown-chats)
 

--- a/docs/15.webhooks/10.background-processing.md
+++ b/docs/15.webhooks/10.background-processing.md
@@ -1,0 +1,163 @@
+---
+title: 'Background Webhook Processing'
+navigation.title: 'Background Processing'
+---
+
+Telegraph handles incoming webhook updates synchronously by default. The webhook controller resolves the bot and configured `WebhookHandler`, calls the handler, and returns HTTP 204 only after the handler finishes.
+
+`Telegraph::dispatch()` does not move this inbound handler work to a queue. It queues only the outbound request from your application to the Telegram Bot API.
+
+For outbound queue selection, worker pools, Horizon, Telegram limits, and current 429 behavior, see [Queued Messages](../12.features/5.queued-messages).
+
+## Keep webhook handlers short
+
+Webhook handlers should validate the update, extract the identifiers required by the application, dispatch heavy work, and finish quickly. Slow API calls, report generation, large database operations, and similar work belong in application-owned Laravel jobs.
+
+For callback queries using an asynchronous queue connection, validate and authorize the input, dispatch the application job, and then acknowledge the callback. Keep validation and queue dispatch short so the acknowledgement remains prompt:
+
+```php
+namespace App\Http\Webhooks;
+
+use App\Jobs\GenerateReport;
+use App\Models\Report;
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+
+class CustomWebhookHandler extends WebhookHandler
+{
+    public function generateReport(): void
+    {
+        $updateId = (int) $this->request->input('update_id');
+        $reportId = filter_var(
+            $this->data->get('report-id'),
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+
+        $report = $reportId === false
+            ? null
+            : Report::query()
+                ->whereKey($reportId)
+                ->where('telegram_chat_id', (string) $this->chat->chat_id)
+                ->first();
+
+        if ($report === null) {
+            $this->reply('Report not available', true);
+
+            return;
+        }
+
+        GenerateReport::dispatch(
+            reportId: (int) $report->getKey(),
+            telegraphBotId: (string) $this->bot->getKey(),
+            telegramChatId: (string) $this->chat->chat_id,
+            updateId: $updateId,
+        )->onQueue('telegram-inbound');
+
+        $this->reply('Report queued');
+    }
+}
+```
+
+Replace the report ownership scope with the host application's authorization policy. Callback data is untrusted request input and must not grant access to a record by itself.
+
+The job receives stable scalar identifiers and loads the records it needs when it runs. The Telegram chat ID remains available even when unknown chats are allowed without storing a `TelegraphChat` model. Do not serialize the HTTP `Request`, a `WebhookHandler`, service clients, bot tokens, webhook secrets, or an entire raw update into the job payload.
+
+## Separate inbound and outbound work
+
+An application job and an outbound Telegraph request are two different queue jobs:
+
+```php
+namespace App\Jobs;
+
+use App\Models\Report;
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Models\TelegraphBot;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class GenerateReport implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public int $reportId,
+        public string $telegraphBotId,
+        public string $telegramChatId,
+        public int $updateId,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        Report::query()
+            ->whereKey($this->reportId)
+            ->where('telegram_chat_id', $this->telegramChatId)
+            ->firstOrFail();
+
+        $timestamp = now();
+
+        $claimed = DB::table('processed_telegram_updates')->insertOrIgnore([
+            'telegraph_bot_id' => $this->telegraphBotId,
+            'update_id' => $this->updateId,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        if ($claimed === 0) {
+            return;
+        }
+
+        /** @var class-string<TelegraphBot> $botModel */
+        $botModel = config('telegraph.models.bot');
+
+        /** @var TelegraphBot $bot */
+        $bot = $botModel::query()->findOrFail($this->telegraphBotId);
+
+        // Perform the application work and build the result...
+
+        Telegraph::bot($bot)
+            ->chat($this->telegramChatId)
+            ->message('Your report is ready')
+            ->dispatch('telegram-interactive');
+    }
+}
+```
+
+In this example:
+
+- `telegram-inbound` contains application processing triggered by webhook updates.
+- `telegram-interactive` contains outbound Telegram API requests.
+- Each queue can have its own worker pool, timeout, retry policy, and capacity.
+
+Keep queue names fixed and operationally manageable. Do not create a queue for every chat or update.
+
+## Idempotency and ordering
+
+Queue jobs may be attempted more than once, and webhook updates can be redelivered. Treat the bot identity together with Telegram's `update_id` as an idempotency input.
+
+The `processed_telegram_updates` table in the example is application-owned and must have a composite unique database index on `telegraph_bot_id` and `update_id`. `insertOrIgnore()` then provides an atomic duplicate-prevention claim before report generation and outbound dispatch.
+
+This simple claim provides at-most-once processing: a process failure after the claim can suppress a later retry. For work that must recover after a crash, store claim status and lease expiry, make the domain operation idempotent, or use a transactional outbox. Do not delete a claim blindly after an error because an external side effect may already have completed.
+
+Multiple workers can process updates concurrently, so queue order is not a per-chat ordering guarantee. When order matters, enforce it in the host application with durable sequence state, locks, or another domain-specific coordination mechanism.
+
+Do not acknowledge an application action as complete merely because its job was dispatched. The job can still fail after the webhook has returned HTTP 204.
+
+## Worker failures
+
+Configure Laravel failed-job storage and monitor queue depth, wait time, and failed-job count for the inbound and outbound queues separately. Retry policy belongs to the host application and should match whether the application operation is idempotent.
+
+Keep runtime logging minimal. Use sanitized job or update identifiers only for WARN and ERROR events needed to investigate failures. Do not write raw webhook payloads, bot tokens, secret headers, message content, or chat and user identifiers to shared logs.
+
+## `max_connections` is not worker capacity
+
+`telegraph.webhook.max_connections` is sent to Telegram when the webhook is registered. It controls how many simultaneous HTTPS connections Telegram may use to deliver updates to the webhook.
+
+It does not configure Laravel queue workers, Horizon balancing, inbound job concurrency, outbound request concurrency, or Telegram API rate limiting. Size those parts independently in the host application.

--- a/docs/15.webhooks/2.registering-webhooks.md
+++ b/docs/15.webhooks/2.registering-webhooks.md
@@ -97,8 +97,10 @@ php artisan telegraph:set-webhook {bot_id} \
 ```
 
 - `--drop-pending-updates` removes pending updates on Telegram when changing the webhook.
-- `--max-connections` sets the maximum allowed simultaneous connections. The default comes from `telegraph.webhook.max_connections`.
+- `--max-connections` sets the maximum simultaneous HTTPS connections Telegram may use to deliver updates. The default comes from `telegraph.webhook.max_connections`.
 - `--secret` passes Telegram the `secret_token`.
+
+`max_connections` controls inbound delivery from Telegram. It does not configure Laravel workers, Horizon balancing, application job concurrency, outbound request concurrency, or Telegram API rate limits. See [Background Webhook Processing](10.background-processing) for production queue boundaries.
 
 ## Allowed updates
 
@@ -147,7 +149,7 @@ For runtime diagnostics, use:
 - `storage/logs/laravel.log` for handler, middleware, and application code errors.
 - The tunnel inspector (`ngrok` web UI or similar) to check incoming `POST` requests.
 
-Do not paste real bot tokens, webhook secrets, Telegram headers, or full user payloads into public issues or shared logs.
+Do not paste real bot tokens, webhook secrets, Telegram headers, full Telegram API URLs, or raw user payloads into public issues or shared logs.
 
 ## Troubleshooting local development
 


### PR DESCRIPTION
## Summary

- document synchronous sending and outbound queue selection
- recommend fixed queues, dedicated worker pools, and optional Horizon supervisors
- document Telegram rate limits, current 429 behavior, and application-owned throttling
- add guidance for background webhook jobs, authorization, idempotency, and ordering

Closes #563

## Testing

- `vendor/bin/pest tests/Unit/Concerns/HasBotsAndChatsTest.php tests/Feature/DocumentationCodeSnippetsTest.php`
- PHP syntax validation for complete documentation examples
- relative documentation link checks
- `git diff --cached --check`